### PR TITLE
Fix OpenGL issues on MacOS

### DIFF
--- a/include/gfx/private.h
+++ b/include/gfx/private.h
@@ -29,6 +29,7 @@ struct {
 	SDL_PixelFormat *format;
 	struct {
 		SDL_GLContext context;
+		GLuint vao;
 		GLuint vbo;
 		GLuint ibo;
 	} gl;

--- a/shaders/blend_amap_alpha.f.glsl
+++ b/shaders/blend_amap_alpha.f.glsl
@@ -16,14 +16,14 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform float threshold;
 
 in vec2 tex_coord;
 out vec4 frag_color;
 
 void main() {
-        vec4 texel = texture2D(texture, tex_coord);
+        vec4 texel = texture(tex, tex_coord);
         texel.a *= threshold;
         frag_color = texel;
 }

--- a/shaders/copy.f.glsl
+++ b/shaders/copy.f.glsl
@@ -16,11 +16,11 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 
 in vec2 tex_coord;
 out vec4 frag_color;
 
 void main() {
-        frag_color = texture2D(texture, tex_coord);
+        frag_color = texture(tex, tex_coord);
 }

--- a/shaders/copy_key.f.glsl
+++ b/shaders/copy_key.f.glsl
@@ -16,14 +16,14 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform vec4 color;
 
 in vec2 tex_coord;
 out vec4 frag_color;
 
 void main() {
-        vec4 texel = texture2D(texture, tex_coord);
+        vec4 texel = texture(tex, tex_coord);
         if (texel.rgb == color.rgb)
                 discard;
         frag_color = texel;

--- a/shaders/copy_use_amap_border.f.glsl
+++ b/shaders/copy_use_amap_border.f.glsl
@@ -16,14 +16,14 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform float threshold;
 
 in vec2 tex_coord;
 out vec4 frag_color;
 
 void main() {
-        vec4 texel = texture2D(texture, tex_coord);
+        vec4 texel = texture(tex, tex_coord);
         if (texel.a < threshold)
                 discard;
         frag_color = texel;

--- a/shaders/copy_use_amap_under.f.glsl
+++ b/shaders/copy_use_amap_under.f.glsl
@@ -16,14 +16,14 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform float threshold;
 
 in vec2 tex_coord;
 out vec4 frag_color;
 
 void main() {
-        vec4 texel = texture2D(texture, tex_coord);
+        vec4 texel = texture(tex, tex_coord);
         if (texel.w > threshold)
                 discard;
         frag_color = texel;

--- a/shaders/hitbox.f.glsl
+++ b/shaders/hitbox.f.glsl
@@ -16,7 +16,7 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform vec2 bot_left;
 uniform vec2 top_right;
 
@@ -29,11 +29,11 @@ float point_in_rect(vec2 p, vec2 bot_left, vec2 top_right) {
 }
 
 void main() {
-        ivec2 size = textureSize(texture, 0);
+        ivec2 size = textureSize(tex, 0);
         vec2 tex_bot_left = bot_left / size;
         vec2 tex_top_right = top_right / size;
 
-        vec4 texel = texture2D(texture, tex_coord);
+        vec4 texel = texture(tex, tex_coord);
         float t = point_in_rect(tex_coord, tex_bot_left, tex_top_right);
         frag_color = t * texel + (1 - t) * vec4(0, 0, 0, 0);
 }

--- a/shaders/hitbox_noblend.f.glsl
+++ b/shaders/hitbox_noblend.f.glsl
@@ -16,7 +16,7 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform vec2 bot_left;
 uniform vec2 top_right;
 
@@ -29,11 +29,11 @@ float point_in_rect(vec2 p, vec2 bot_left, vec2 top_right) {
 }
 
 void main() {
-        ivec2 size = textureSize(texture, 0);
+        ivec2 size = textureSize(tex, 0);
         vec2 tex_bot_left = bot_left / size;
         vec2 tex_top_right = top_right / size;
 
-        vec4 texel = texture2D(texture, tex_coord);
+        vec4 texel = texture(tex, tex_coord);
         texel.a = 1;
         float t = point_in_rect(tex_coord, tex_bot_left, tex_top_right);
         frag_color = t * texel + (1 - t) * vec4(0, 0, 0, 0);

--- a/shaders/render.f.glsl
+++ b/shaders/render.f.glsl
@@ -16,13 +16,13 @@
 
 #version 140
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform float alpha_mod;
 
 in vec2 tex_coord;
 out vec4 frag_color;
 
 void main() {
-        frag_color = texture2D(texture, tex_coord);
+        frag_color = texture(tex, tex_coord);
         frag_color.a *= alpha_mod;
 }

--- a/src/video.c
+++ b/src/video.c
@@ -103,7 +103,7 @@ void gfx_load_shader(struct shader *dst, const char *vertex_shader_path, const c
 	dst->program = program;
 	dst->world_transform = glGetUniformLocation(program, "world_transform");
 	dst->view_transform = glGetUniformLocation(program, "view_transform");
-	dst->texture = glGetUniformLocation(program, "texture");
+	dst->texture = glGetUniformLocation(program, "tex");
 	dst->vertex = glGetAttribLocation(program, "vertex_pos");
 	dst->alpha_mod = glGetAttribLocation(program, "alpha_mod");
 	dst->prepare = NULL;
@@ -125,6 +125,9 @@ static int gl_initialize(void)
 	};
 
 	GLuint index_data[] = { 0, 1, 2, 3 };
+
+	glGenVertexArrays(1, &sdl.gl.vao);
+	glBindVertexArray(sdl.gl.vao);
 
 	glGenBuffers(1, &sdl.gl.vbo);
 	glBindBuffer(GL_ARRAY_BUFFER, sdl.gl.vbo);


### PR DESCRIPTION
MacOS [does not support](https://www.khronos.org/opengl/wiki/OpenGL_Context#OpenGL_3.2_and_Profiles) OpenGL compatibility profile, so the following changes had to be made to get graphics:

- Replaced `texture2D()` (deprecated in OpenGL 3.0) with `texture()` in shaders
- Renamed `texture` uniform variable to `tex`, to avoid name conflict
- Use VAO, which is mandatory in OpenGL 3 core profile