### PR TITLE
Fix compile error on Mac

### DIFF
--- a/src/hll/SengokuRanceFont.c
+++ b/src/hll/SengokuRanceFont.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <dirent.h>
+#include <limits.h>
 
 #include "system4.h"
 #include "system4/fnl.h"

--- a/src/system4.c
+++ b/src/system4.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <signal.h>
 #include <getopt.h>
+#include <limits.h>
 
 #include "system4.h"
 #include "system4/ain.h"


### PR DESCRIPTION
Adds `#include <limits.h>` for PATH_MAX.