### PR TITLE
Fix vm_copy() for reference types

### DIFF
--- a/src/page.c
+++ b/src/page.c
@@ -369,6 +369,8 @@ static bool array_index_ok(struct page *array, int i)
 
 void array_copy(struct page *dst, int dst_i, struct page *src, int src_i, int n)
 {
+	if (n <= 0)
+		return;
 	if (!dst || !src)
 		ERROR("Array is NULL");
 	if (dst->type != ARRAY_PAGE || src->type != ARRAY_PAGE)

--- a/src/vm.c
+++ b/src/vm.c
@@ -224,6 +224,9 @@ union vm_value vm_copy(union vm_value v, enum ain_data_type type)
 	case AIN_STRUCT:
 	case AIN_ARRAY_TYPE:
 		return (union vm_value) { .i = vm_copy_page(heap[v.i].page) };
+	case AIN_REF_TYPE:
+		heap_ref(v.i);
+		return v;
 	default:
 		return v;
 	}

--- a/test/Source/arrays.jaf
+++ b/test/Source/arrays.jaf
@@ -212,6 +212,20 @@ void test_array_constructors(void)
 	test_bool("array constructors", !failed, true);
 }
 
+struct struct_with_ref {
+	ref inner_struct s;
+};
+
+void test_array_push_struct_with_ref(void)
+{
+	array@struct_with_ref ar;
+	struct_with_ref o;
+	inner_struct i;
+	o.s <- i;
+	ar.PushBack(o);
+	// Returning from this function should not double-free i.
+}
+
 void test_arrays(void)
 {
 	test_array_set();
@@ -227,4 +241,5 @@ void test_arrays(void)
 	test_array_insert();
 	test_array_sort();
 	test_array_constructors();
+	test_array_push_struct_with_ref();
 }


### PR DESCRIPTION
This fixes a memory corruption bug when reference values are copied into arrays, and also fix a test failure in `test_array_copy()`.