### PR TITLE
Fix SACT2.SP_GetMaxZ

### DIFF
--- a/include/sact.h
+++ b/include/sact.h
@@ -35,7 +35,7 @@ int sact_Effect(int type, int time, int key);
 int sact_SP_GetUnuseNum(int min);
 int sact_SP_Count(void);
 int sact_SP_Enum(struct page **array);
-#define sact_SP_GetMaxZ scene_get_max_z
+int sact_SP_GetMaxZ(void);
 int sact_SP_SetCG(int sp, int cg);
 int sact_SP_SetCGFromFile(int sp, struct string *filename);
 int sact_SP_SaveCG(int sp, struct string *filename);

--- a/include/scene.h
+++ b/include/scene.h
@@ -47,7 +47,6 @@ void scene_render(void);
 void scene_flip(void);
 int scene_set_wp(int cg_no);
 int scene_set_wp_color(int r, int g, int b);
-int scene_get_max_z(void);
 void scene_set_sprite_z(struct sprite *sp, int z);
 void scene_set_sprite_z2(struct sprite *sp, int z, int z2);
 

--- a/src/hll/SACT2.c
+++ b/src/hll/SACT2.c
@@ -183,6 +183,16 @@ int sact_SP_Enum(struct page **array)
 	return count;
 }
 
+int sact_SP_GetMaxZ(void)
+{
+	int max_z = 0;
+	for (int i = 0; i < nr_sprites; i++) {
+		if (sprites[i] && max_z < sprites[i]->sp.z)
+			max_z = sprites[i]->sp.z;
+	}
+	return max_z;
+}
+
 int sact_SP_SetCG(int sp_no, int cg_no)
 {
 	struct sact_sprite *sp = sact_get_sprite(sp_no);

--- a/src/scene.c
+++ b/src/scene.c
@@ -112,13 +112,6 @@ int scene_set_wp_color(int r, int g, int b)
 	return 1;
 }
 
-int scene_get_max_z(void)
-{
-	if (TAILQ_EMPTY(&sprite_list))
-		return 0;
-	return TAILQ_LAST(&sprite_list, listhead)->z;
-}
-
 void scene_set_sprite_z(struct sprite *sp, int z)
 {
 	sp->z = z;


### PR DESCRIPTION
It should return the maximum Z value among all sprites, not among visible sprites.

This fixes a bug in Rance VI where some UI elements are incorrectly Z-ordered.