### PR TITLE
Support OpenGL ES 3.0

### DIFF
--- a/include/gfx/gfx.h
+++ b/include/gfx/gfx.h
@@ -87,7 +87,7 @@ void gfx_init_texture_blank(struct texture *t, int w, int h);
 void gfx_init_texture_with_cg(struct texture *t, struct cg *cg);
 void gfx_init_texture_rgba(struct texture *t, int w, int h, SDL_Color color);
 void gfx_init_texture_rgb(struct texture *t, int w, int h, SDL_Color color);
-void gfx_init_texture_with_pixels(struct texture *t, int w, int h, void *pixels, GLenum format);
+void gfx_init_texture_with_pixels(struct texture *t, int w, int h, void *pixels);
 void gfx_copy_main_surface(struct texture *dst);
 void gfx_delete_texture(struct texture *t);
 GLuint gfx_set_framebuffer(GLenum target, Texture *t, int x, int y, int w, int h);

--- a/shaders/blend_amap_alpha.f.glsl
+++ b/shaders/blend_amap_alpha.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform float threshold;
 

--- a/shaders/blend_amap_color.f.glsl
+++ b/shaders/blend_amap_color.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform vec4 color;
 

--- a/shaders/copy.f.glsl
+++ b/shaders/copy.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 
 in vec2 tex_coord;

--- a/shaders/copy_alpha_key.f.glsl
+++ b/shaders/copy_alpha_key.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform vec4 color;
 

--- a/shaders/copy_color_reverse.f.glsl
+++ b/shaders/copy_color_reverse.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 
 in vec2 tex_coord;

--- a/shaders/copy_key.f.glsl
+++ b/shaders/copy_key.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform vec4 color;
 

--- a/shaders/copy_use_amap_border.f.glsl
+++ b/shaders/copy_use_amap_border.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform float threshold;
 

--- a/shaders/copy_use_amap_under.f.glsl
+++ b/shaders/copy_use_amap_under.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform float threshold;
 

--- a/shaders/dungeon.f.glsl
+++ b/shaders/dungeon.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform float alpha_mod;
 

--- a/shaders/dungeon.v.glsl
+++ b/shaders/dungeon.v.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform mat4 local_transform;
 uniform mat4 view_transform;
 uniform mat4 proj_transform;

--- a/shaders/dungeon_skybox.f.glsl
+++ b/shaders/dungeon_skybox.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform samplerCube tex;
 
 in vec3 tex_coord;

--- a/shaders/dungeon_skybox.v.glsl
+++ b/shaders/dungeon_skybox.v.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform mat4 view_transform;
 uniform mat4 proj_transform;
 

--- a/shaders/fill.f.glsl
+++ b/shaders/fill.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform vec4 color;
 
 in vec2 tex_coord;

--- a/shaders/fill_amap_over_border.f.glsl
+++ b/shaders/fill_amap_over_border.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform float threshold;
 uniform vec4 color;

--- a/shaders/fill_amap_under_border.f.glsl
+++ b/shaders/fill_amap_under_border.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform float threshold;
 uniform vec4 color;

--- a/shaders/hitbox.f.glsl
+++ b/shaders/hitbox.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform vec2 bot_left;
 uniform vec2 top_right;
@@ -29,11 +27,11 @@ float point_in_rect(vec2 p, vec2 bot_left, vec2 top_right) {
 }
 
 void main() {
-        ivec2 size = textureSize(tex, 0);
+        vec2 size = vec2(textureSize(tex, 0));
         vec2 tex_bot_left = bot_left / size;
         vec2 tex_top_right = top_right / size;
 
         vec4 texel = texture(tex, tex_coord);
         float t = point_in_rect(tex_coord, tex_bot_left, tex_top_right);
-        frag_color = t * texel + (1 - t) * vec4(0, 0, 0, 0);
+        frag_color = t * texel + (1.0 - t) * vec4(0, 0, 0, 0);
 }

--- a/shaders/hitbox_noblend.f.glsl
+++ b/shaders/hitbox_noblend.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform vec2 bot_left;
 uniform vec2 top_right;
@@ -29,12 +27,12 @@ float point_in_rect(vec2 p, vec2 bot_left, vec2 top_right) {
 }
 
 void main() {
-        ivec2 size = textureSize(tex, 0);
+        vec2 size = vec2(textureSize(tex, 0));
         vec2 tex_bot_left = bot_left / size;
         vec2 tex_top_right = top_right / size;
 
         vec4 texel = texture(tex, tex_coord);
-        texel.a = 1;
+        texel.a = 1.0;
         float t = point_in_rect(tex_coord, tex_bot_left, tex_top_right);
-        frag_color = t * texel + (1 - t) * vec4(0, 0, 0, 0);
+        frag_color = t * texel + (1.0 - t) * vec4(0, 0, 0, 0);
 }

--- a/shaders/render.f.glsl
+++ b/shaders/render.f.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform sampler2D tex;
 uniform float alpha_mod;
 

--- a/shaders/render.v.glsl
+++ b/shaders/render.v.glsl
@@ -14,8 +14,6 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#version 140
-
 uniform mat4 world_transform;
 uniform mat4 view_transform;
 

--- a/src/fnl_render.c
+++ b/src/fnl_render.c
@@ -111,7 +111,7 @@ static void render_text(struct fnl_font_face *font, struct text_style *ts, Textu
 	}
 
 	// create texture from surface
-	gfx_init_texture_with_pixels(dst, width, height, surf, GL_RGBA);
+	gfx_init_texture_with_pixels(dst, width, height, surf);
 	free(surf);
 	free(glyphs);
 }

--- a/src/text.c
+++ b/src/text.c
@@ -252,10 +252,12 @@ static void get_glyph(TTF_Font *f, Texture *dst, char *msg, SDL_Color color)
 		WARNING("Text rendering failed: %s", msg);
 		return;
 	}
-	if (s->format->format != SDL_PIXELFORMAT_BGRA32) {
-		WARNING("Wrong pixel format from SDL_ttf");
+	if (s->format->format != SDL_PIXELFORMAT_RGBA32) {
+		SDL_Surface *tmp = SDL_ConvertSurfaceFormat(s, SDL_PIXELFORMAT_RGBA32, 0);
+		SDL_FreeSurface(s);
+		s = tmp;
 	}
-	gfx_init_texture_with_pixels(dst, s->w, s->h, s->pixels, GL_BGRA);
+	gfx_init_texture_with_pixels(dst, s->w, s->h, s->pixels);
 	SDL_FreeSurface(s);
 }
 

--- a/src/video.c
+++ b/src/video.c
@@ -428,15 +428,15 @@ static void init_texture(struct texture *t, int w, int h)
 
 }
 
-void gfx_init_texture_with_pixels(struct texture *t, int w, int h, void *pixels, GLenum format)
+void gfx_init_texture_with_pixels(struct texture *t, int w, int h, void *pixels)
 {
 	init_texture(t, w, h);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, format, GL_UNSIGNED_BYTE, pixels);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 }
 
 void gfx_init_texture_with_cg(struct texture *t, struct cg *cg)
 {
-	gfx_init_texture_with_pixels(t, cg->metrics.w, cg->metrics.h, cg->pixels, GL_RGBA);
+	gfx_init_texture_with_pixels(t, cg->metrics.w, cg->metrics.h, cg->pixels);
 	t->has_alpha = cg->metrics.has_alpha;
 }
 
@@ -449,7 +449,7 @@ void gfx_init_texture_rgba(struct texture *t, int w, int h, SDL_Color color)
 		pixels[i] = c;
 	}
 
-	gfx_init_texture_with_pixels(t, w, h, pixels, GL_RGBA);
+	gfx_init_texture_with_pixels(t, w, h, pixels);
 	free(pixels);
 }
 
@@ -469,7 +469,7 @@ void gfx_init_texture_rgb(struct texture *t, int w, int h, SDL_Color color)
 
 void gfx_init_texture_blank(struct texture *t, int w, int h)
 {
-	gfx_init_texture_with_pixels(t, w, h, NULL, GL_RGBA);
+	gfx_init_texture_with_pixels(t, w, h, NULL);
 }
 
 void gfx_copy_main_surface(struct texture *dst)


### PR DESCRIPTION
This adds a compile-time flag to use OpenGL ES 3.0, paving the way to support more platforms (Android, WebGL, etc.)

I tested this on Raspberry Pi 4 (my primary Linux desktop environment). Rance VI's dungeon benchmark marked 170 fps with OpenGL ES3, while it was ~25 fps with the OpenGL3 software renderer.
