### PR TITLE
Use OpenGL ES directly if `USE_GLES` is defined

### DIFF
--- a/include/dungeon/dungeon.h
+++ b/include/dungeon/dungeon.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 
 struct page;
 struct dgn;

--- a/include/dungeon/renderer.h
+++ b/include/dungeon/renderer.h
@@ -18,7 +18,7 @@
 #define SYSTEM4_DUNGEON_RENDERER_H
 
 #include <cglm/cglm.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 
 struct dgn_cell;
 struct dtx;

--- a/include/gfx/gfx.h
+++ b/include/gfx/gfx.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <SDL.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 #include "gfx/types.h"
 
 struct cg;

--- a/include/gfx/gl.h
+++ b/include/gfx/gl.h
@@ -17,11 +17,6 @@
 #ifndef SYSTEM4_GFX_GL_H
 #define SYSTEM4_GFX_GL_H
 
-/*
- * Define this to target OpenGL ES 3.0.
- */
-//#define USE_GLES
-
 #ifdef USE_GLES
 #include <GLES3/gl3.h>
 #else

--- a/include/gfx/gl.h
+++ b/include/gfx/gl.h
@@ -1,7 +1,4 @@
-/* gfx/private.h  SDL/OpenGL only private data
- *
- * Copyright (C) 2019 Nunuhara Cabbage <nunuhara@haniwa.technology>
- * Copyright (C) 2000- Fumihiko Murata <fmurata@p1.tcnet.ne.jp>
+/* Copyright (C) 2021 kichikuou <KichikuouChrome@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,26 +14,18 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#ifndef SYSTEM4_GFX_PRIVATE_H
-#define SYSTEM4_GFX_PRIVATE_H
+#ifndef SYSTEM4_GFX_GL_H
+#define SYSTEM4_GFX_GL_H
 
-#include <stdbool.h>
-#include <SDL.h>
-#include "gfx/gl.h"
+/*
+ * Define this to target OpenGL ES 3.0.
+ */
+//#define USE_GLES
 
-struct sdl_private {
-	SDL_Window *window;
-	SDL_PixelFormat *format;
-	struct {
-		SDL_GLContext context;
-		GLuint vao;
-		GLuint vbo;
-		GLuint ibo;
-	} gl;
-	int w, h;
-	bool ms_active; /* mouse is active */
-	bool fs_on;
-};
-extern struct sdl_private sdl;
+#ifdef USE_GLES
+#include <GLES3/gl3.h>
+#else
+#include <GL/glew.h>
+#endif
 
-#endif /* SYSTEM4_GFX_PRIVATE_H */
+#endif /* SYSTEM4_GFX_GL_H */

--- a/meson.build
+++ b/meson.build
@@ -8,13 +8,21 @@ libm = meson.get_compiler('c').find_library('m', required: false)
 sdl2 = dependency('sdl2')
 sdl2ttf = dependency('SDL2_ttf')
 ffi = dependency('libffi')
-gl = dependency('GL')
-glew = dependency('glew')
 tj = dependency('libturbojpeg')
 webp = dependency('libwebp')
 png = dependency('libpng')
 cglm = dependency('cglm', fallback : ['cglm', 'cglm_dep'])
 sndfile = dependency('sndfile')
+
+if get_option('use_gles')
+    gles = dependency('glesv2')
+    gl_deps = [gles]
+    add_project_arguments('-DUSE_GLES', language : 'c')
+else
+    gl = dependency('GL')
+    glew = dependency('glew')
+    gl_deps = [gl, glew]
+endif
 
 chibi = dependency('chibi-scheme', required : get_option('debugger'))
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('debugger', type : 'feature', value : 'auto')
+option('use_gles', type : 'boolean', value : false, description : 'Target OpenGL ES 3.0')

--- a/src/draw.c
+++ b/src/draw.c
@@ -16,7 +16,7 @@
 
 #include <math.h>
 #include <SDL.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 #include <cglm/cglm.h>
 
 #include "gfx/gfx.h"

--- a/src/dungeon/dungeon.c
+++ b/src/dungeon/dungeon.c
@@ -19,7 +19,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <cglm/cglm.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 #include "system4.h"
 #include "system4/alk.h"
 #include "system4/archive.h"

--- a/src/dungeon/renderer.c
+++ b/src/dungeon/renderer.c
@@ -18,7 +18,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <cglm/cglm.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 #include "system4.h"
 #include "system4/buffer.h"
 #include "system4/cg.h"

--- a/src/dungeon/skybox.c
+++ b/src/dungeon/skybox.c
@@ -15,7 +15,7 @@
  */
 
 #include <stdlib.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 #include "system4.h"
 #include "system4/cg.h"
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -81,7 +81,7 @@ xsystem4 = ['audio.c',
             'hll/VSFile.c',
 ]
 
-xsystem4_deps = [libm, zlib, sdl2, sdl2ttf, ffi, gl, glew, cglm, sndfile, libsys4_dep]
+xsystem4_deps = [libm, zlib, sdl2, sdl2ttf, ffi, cglm, sndfile, libsys4_dep] + gl_deps
 
 if chibi.found()
     xsystem4_deps += chibi

--- a/src/video.c
+++ b/src/video.c
@@ -16,7 +16,7 @@
  */
 
 #include <SDL.h>
-#include <GL/glew.h>
+#include "gfx/gl.h"
 #include <cglm/cglm.h>
 #include <string.h>
 #include <errno.h>
@@ -32,11 +32,6 @@
 #include "xsystem4.h"
 
 struct sdl_private sdl;
-
-/*
- * Define this to target OpenGL ES 3.0.
- */
-//#define USE_GLES
 
 static const GLchar glsl_preamble[] =
 #ifdef USE_GLES
@@ -218,10 +213,12 @@ int gfx_init(void)
 	if (!sdl.gl.context)
 		ERROR("SDL_GL_CreateContext failed: %s", SDL_GetError());
 
+#ifndef USE_GLES
 	glewExperimental = GL_TRUE;
 	GLenum err = glewInit();
 	if (err != GLEW_OK && err != GLEW_ERROR_NO_GLX_DISPLAY)
 		ERROR("glewInit failed");
+#endif
 
 	SDL_GL_SetSwapInterval(0);
 	gl_initialize();


### PR DESCRIPTION
GLEW does not support OpenGL ES so it should not be used when targeting OpenGL ES.