### PR TITLE
Make the window resizable

### DIFF
--- a/include/gfx/gfx.h
+++ b/include/gfx/gfx.h
@@ -67,8 +67,8 @@ int gfx_init(void);
 void gfx_fini(void);
 
 Texture *gfx_main_surface(void);
-void gfx_set_window_size(int w, int h);
-void gfx_fullscreen(bool on);
+void gfx_set_window_logical_size(int w, int h);
+void gfx_update_screen_scale(void);
 void gfx_set_wait_vsync(bool wait);
 
 void gfx_load_shader(struct shader *dst, const char *vertex_shader_path, const char *fragment_shader_path);

--- a/include/gfx/private.h
+++ b/include/gfx/private.h
@@ -34,8 +34,8 @@ struct sdl_private {
 		GLuint ibo;
 	} gl;
 	int w, h;
+	SDL_Rect viewport;
 	bool ms_active; /* mouse is active */
-	bool fs_on;
 };
 extern struct sdl_private sdl;
 

--- a/src/input.c
+++ b/src/input.c
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include <SDL.h>
 #include "system4.h"
+#include "gfx/gfx.h"
 #include "gfx/private.h"
 #include "input.h"
 #include "scene.h"
@@ -207,13 +208,18 @@ void joy_clear_flag(void)
 
 void mouse_get_pos(int *x, int *y)
 {
+	int wx, wy;
 	SDL_PumpEvents();
-	SDL_GetMouseState(x, y);
+	SDL_GetMouseState(&wx, &wy);
+	*x = (wx - sdl.viewport.x) * sdl.w / sdl.viewport.w;
+	*y = (wy - sdl.viewport.y) * sdl.h / sdl.viewport.h;
 }
 
 void mouse_set_pos(int x, int y)
 {
-	SDL_WarpMouseInWindow(sdl.window, x, y);
+	int wx = x * sdl.viewport.w / sdl.w + sdl.viewport.x;
+	int wy = y * sdl.viewport.h / sdl.h + sdl.viewport.y;
+	SDL_WarpMouseInWindow(sdl.window, wx, wy);
 }
 
 static int wheel_dir = 0;
@@ -300,6 +306,10 @@ void handle_events(void)
 				break;
 			case SDL_WINDOWEVENT_FOCUS_LOST:
 				keyboard_focus = false;
+				break;
+			case SDL_WINDOWEVENT_SIZE_CHANGED:
+				gfx_update_screen_scale();
+				scene_flip();
 				break;
 			}
 			break;


### PR DESCRIPTION
We don't use SDL's rendering functions, so we have to scale the screen and translate the mouse positions ourselves.

I implemented this to make the graphics fit the screen on Android, but it could be useful on other platforms as well.