### PR TITLE
Fix out-of-bounds access in audio_mixer.c

### DIFF
--- a/src/audio_mixer.c
+++ b/src/audio_mixer.c
@@ -131,7 +131,6 @@ static bool cb_seek(struct channel *ch, uint_least32_t pos)
 static bool cb_loop(struct channel *ch)
 {
 	if (!cb_seek(ch, ch->loop_start) || ch->loop_count == 1) {
-		ch->voice = -1;
 		return false;
 	}
 	if (ch->loop_count > 1) {


### PR DESCRIPTION
This fixes a bug in Rance VI where sound effects stopped working after the first battle, caused by memory corruption in audio_mixer.c.

When `cb_loop()` called from `refill_stream()` set `ch->voice` to -1, out-of-bounds access occured later in `refill_stream()` at this line.

		mixers[ch->mixer_no].mixer.voices[ch->voice].gain = gain;

`cb_loop()` shouldn't need to change `ch->voice`, because `refill_stream()` does that when `cb_loop()` returns false.
