### PR TITLE
Fix date/time getter functions

### DIFF
--- a/src/hll/File.c
+++ b/src/hll/File.c
@@ -175,7 +175,7 @@ static int File_GetTime(struct string *filename, struct page **page)
 	}
 
 	date[0].i = tm->tm_year + 1900;
-	date[1].i = tm->tm_mon;
+	date[1].i = tm->tm_mon + 1;
 	date[2].i = tm->tm_mday;
 	date[3].i = tm->tm_hour;
 	date[4].i = tm->tm_min;

--- a/src/util.c
+++ b/src/util.c
@@ -152,8 +152,8 @@ void get_date(int *year, int *month, int *mday, int *wday)
 	time_t t = time(NULL);
 	struct tm *tm = localtime(&t);
 
-	*year  = tm->tm_year;
-	*month = tm->tm_mon;
+	*year  = tm->tm_year + 1900;
+	*month = tm->tm_mon + 1;
 	*mday  = tm->tm_mday;
 	*wday  = tm->tm_wday;
 }
@@ -167,6 +167,6 @@ void get_time(int *hour, int *min, int *sec, int *ms)
 
 	*hour = tm->tm_hour;
 	*min  = tm->tm_min;
-	*sec  = ts.tv_sec;
+	*sec  = tm->tm_sec;
 	*ms   = ts.tv_nsec / 1000000;
 }


### PR DESCRIPTION
Values returned by `SACT2.System_GetDate` etc. should correspond to the Windows `SYSTEMTIME` structure, not `struct tm`.

This also fixes a bug where `get_time()` returns a value greater than 60 for `sec`.