### PR TITLE
ReignEngine: Fix billboard rendering issue

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -120,6 +120,11 @@ void gfx_load_shader(struct shader *dst, const char *vertex_shader_path, const c
 
 	glAttachShader(program, vertex_shader);
 	glAttachShader(program, fragment_shader);
+
+	// In OpenGL < 3.2, Attribute location 0 is special. Make sure it's assigned
+	// to the vertex position.
+	glBindAttribLocation(program, 0, "vertex_pos");
+
 	glLinkProgram(program);
 
 	GLint link_success;


### PR DESCRIPTION
This fixes an issue where billboard objects are not drawn in some environments.

ReignEngine disables some vertex attributes when drawing billboards, but AMD's driver doesn't draw anything if any of those attributes are assigned to attribute index 0.

To avoid this, this explicitly binds "vertex_pos" attribute (which is always enabled) to index 0.

References:
https://community.khronos.org/t/gldisablevertexattribarray-not-working/67077/4
https://stackoverflow.com/questions/28818997/how-to-use-glvertexattrib