### PR TITLE
ReignEngine: Implement CalcInstanceHeightDetection

### DIFF
--- a/include/reign.h
+++ b/include/reign.h
@@ -105,6 +105,7 @@ struct RE_instance {
 	struct model *model;
 	struct motion *motion;
 	struct motion *next_motion;
+	struct height_detector *height_detector;
 
 	enum RE_instance_type type;
 	vec3 pos;
@@ -150,6 +151,7 @@ bool RE_instance_free_next_motion(struct RE_instance *instance);
 bool RE_instance_set_vertex_pos(struct RE_instance *instance, int index, float x, float y, float z);
 int RE_instance_get_bone_index(struct RE_instance *instance, const char *name);
 bool RE_instance_trans_local_pos_to_world_pos_by_bone(struct RE_instance *instance, int bone, vec3 offset, vec3 out);
+float RE_instance_calc_height(struct RE_instance *instance, float x, float z);
 
 int RE_motion_get_state(struct motion *motion);
 bool RE_motion_set_state(struct motion *motion, int state);

--- a/shaders/reign_shadow.f.glsl
+++ b/shaders/reign_shadow.f.glsl
@@ -14,5 +14,8 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
+out uvec4 frag_color;
+
 void main() {
+	frag_color.r = uint(gl_FragCoord.z * 65535.0);
 }

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -163,6 +163,9 @@ void motion_free(struct motion *motion);
 struct RE_renderer *RE_renderer_new(struct texture *texture);
 void RE_renderer_free(struct RE_renderer *r);
 bool RE_renderer_load_billboard_texture(struct RE_renderer *r, int cg_no);
+struct height_detector *RE_renderer_create_height_detector(struct RE_renderer *r, struct model *model);
+void RE_renderer_free_height_detector(struct height_detector *hd);
+float RE_renderer_detect_height(struct height_detector *hd, float x, float z);
 
 // parser.c
 

--- a/src/3d/reign.c
+++ b/src/3d/reign.c
@@ -66,6 +66,10 @@ static void unload_instance(struct RE_instance *instance)
 		free(instance->bone_transforms);
 		instance->bone_transforms = NULL;
 	}
+	if (instance->height_detector) {
+		RE_renderer_free_height_detector(instance->height_detector);
+		instance->height_detector = NULL;
+	}
 }
 
 static void free_instance(struct RE_instance *instance)
@@ -372,6 +376,17 @@ bool RE_instance_trans_local_pos_to_world_pos_by_bone(struct RE_instance *instan
 	glm_mat4_mulv3(instance->bone_transforms[bone], offset, 1.0, out);
 	glm_mat4_mulv3(instance->local_transform, out, 1.0, out);
 	return true;
+}
+
+float RE_instance_calc_height(struct RE_instance *instance, float x, float z)
+{
+	if (!instance || !instance->model)
+		return 0.0;
+	if (!instance->height_detector) {
+		instance->height_detector = RE_renderer_create_height_detector(instance->plugin->renderer, instance->model);
+	}
+	float y = RE_renderer_detect_height(instance->height_detector, x, z);
+	return y;
 }
 
 void RE_instance_update_local_transform(struct RE_instance *inst)

--- a/src/hll/ReignEngine.c
+++ b/src/hll/ReignEngine.c
@@ -523,7 +523,12 @@ static bool ReignEngine_TransInstanceLocalPosToWorldPosByBone(int plugin, int in
 //int ReignEngine_GetInstanceTextureMemorySize(int plugin, int instance);
 //void ReignEngine_GetInstanceInfoText(int plugin, int instance, struct string **pIText);
 //void ReignEngine_GetInstanceMaterialInfoText(int plugin, int instance, struct string **pIText);
-HLL_WARN_UNIMPLEMENTED(0.0, float, ReignEngine, CalcInstanceHeightDetection, int plugin, int instance, float x, float z);
+
+static float ReignEngine_CalcInstanceHeightDetection(int plugin, int instance, float x, float z)
+{
+	return RE_instance_calc_height(get_instance(plugin, instance), x, -z);
+}
+
 //float ReignEngine_GetInstanceSoftFogEdgeLength(int plugin, int instance);
 HLL_WARN_UNIMPLEMENTED(false, bool, ReignEngine, SetInstanceSoftFogEdgeLength, int plugin, int instance, float length);
 


### PR DESCRIPTION
This is used to compute Y-positions of map objects.

It is called quite often, so this implementation creates and caches a height map of the instance by (re)using the shader for shadow mapping.