### PR TITLE
Fix text rendering issue in OpenGL ES

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -532,7 +532,7 @@ void gfx_init_texture_amap(struct texture *t, int w, int h, uint8_t *amap, SDL_C
 void gfx_init_texture_rmap(struct texture *t, int w, int h, uint8_t *rmap)
 {
 	init_texture(t, w, h);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, rmap);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, rmap);
 }
 
 void gfx_init_texture_blank(struct texture *t, int w, int h)


### PR DESCRIPTION
This fixes an issue where text is not rendered on Android.

In OpenGL ES3.0, `GL_RED` is not a valid value for the `internalFormat` parameter of `glTexImage2D`.