### PR TITLE
ReignEngine: Per-mesh control of drawing order

### DIFF
--- a/include/reign.h
+++ b/include/reign.h
@@ -152,7 +152,6 @@ struct RE_instance {
 	vec3 globe_diffuse;
 
 	// Private
-	bool is_transparent;
 	bool local_transform_needs_update;
 	mat4 local_transform;
 	mat3 normal_transform;

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -44,7 +44,7 @@ struct model {
 	struct hash_table *bone_map;  // bone id in POL/MOT -> struct bone *
 	struct hash_table *bone_name_map;  // bone name -> (struct bone * | NULL)
 	vec3 aabb[2];  // axis-aligned bounding box
-	bool is_transparent;
+	bool has_transparent_material;
 };
 
 struct mesh {
@@ -185,7 +185,7 @@ struct archive_data *RE_get_aar_entry(struct archive *aar, const char *dir, cons
 
 struct RE_renderer *RE_renderer_new(struct texture *texture);
 void RE_renderer_free(struct RE_renderer *r);
-struct billboard_texture *RE_renderer_load_billboard_texture(struct RE_renderer *r, int cg_no);
+bool RE_renderer_load_billboard_texture(struct RE_renderer *r, int cg_no);
 struct height_detector *RE_renderer_create_height_detector(struct RE_renderer *r, struct model *model);
 void RE_renderer_free_height_detector(struct height_detector *hd);
 float RE_renderer_detect_height(struct height_detector *hd, float x, float z);

--- a/src/3d/debug.c
+++ b/src/3d/debug.c
@@ -87,8 +87,11 @@ static void print_instance(struct RE_instance *inst, int index, int indent)
 		indent_printf(indent, "scale = {x=%f, y=%f, z=%f},\n", SPREAD_VEC3(inst->scale));
 		indent_printf(indent, "ambient = {r=%f, g=%f, b=%f},\n", SPREAD_VEC3(inst->ambient));
 	}
-	if (inst->model)
+	if (inst->model) {
 		indent_printf(indent, "path = \"%s\",\n", inst->model->path);
+		indent_printf(indent, "aabb = {min = {x=%f, y=%f, z=%f}, max = {x=%f, y=%f, z=%f}},\n",
+			      SPREAD_VEC3(inst->model->aabb[0]), SPREAD_VEC3(inst->model->aabb[1]));
+	}
 	if (inst->motion) {
 		indent_printf(indent, "fps = %f,\n", inst->fps);
 		print_motion("motion", inst->motion, indent);
@@ -99,7 +102,6 @@ static void print_instance(struct RE_instance *inst, int index, int indent)
 		indent_printf(indent, "motion_blend_rate = %f,\n", inst->motion_blend_rate);
 	if (inst->effect)
 		indent_printf(indent, "path = \"%s\",\n", inst->effect->path);
-	indent_printf(indent, "is_transparent = %d,\n", inst->is_transparent);
 
 	indent--;
 	indent_printf(indent, "},\n");

--- a/src/3d/model.c
+++ b/src/3d/model.c
@@ -443,7 +443,7 @@ struct model *model_load(struct archive *aar, const char *path)
 	}
 	for (int i = 0; i < model->nr_materials; i++) {
 		if (model->materials[i].alpha_map) {
-			model->is_transparent = true;
+			model->has_transparent_material = true;
 			break;
 		}
 	}

--- a/src/3d/reign.c
+++ b/src/3d/reign.c
@@ -349,7 +349,6 @@ bool RE_instance_load(struct RE_instance *instance, const char *name)
 		instance->model = model_load(instance->plugin->aar, name);
 		if (instance->model && instance->model->nr_bones > 0)
 			instance->bone_transforms = xcalloc(instance->model->nr_bones, sizeof(mat4));
-		instance->is_transparent = instance->model->is_transparent;
 		return !!instance->model;
 	case RE_ITYPE_PARTICLE_EFFECT:
 		instance->effect = particle_effect_load(instance->plugin->aar, name);
@@ -358,7 +357,6 @@ bool RE_instance_load(struct RE_instance *instance, const char *name)
 			instance->motion->instance = instance;
 			particle_effect_calc_frame_range(instance->effect, instance->motion);
 		}
-		instance->is_transparent = true;
 		return !!instance->effect;
 	default:
 		WARNING("Invalid instance type %d", instance->type);
@@ -501,11 +499,8 @@ bool RE_motion_set_frame_range(struct motion *motion, float begin, float end)
 	motion->frame_end = end;
 	if (motion->instance->type == RE_ITYPE_BILLBOARD) {
 		for (int i = begin; i < end; i++) {
-			struct billboard_texture *bt = RE_renderer_load_billboard_texture(motion->instance->plugin->renderer, i);
-			if (!bt)
+			if (!RE_renderer_load_billboard_texture(motion->instance->plugin->renderer, i))
 				return false;
-			if (bt->has_alpha)
-				motion->instance->is_transparent = true;
 		}
 	}
 	return true;
@@ -519,11 +514,8 @@ bool RE_motion_set_loop_frame_range(struct motion *motion, float begin, float en
 	motion->loop_frame_end = end;
 	if (motion->instance->type == RE_ITYPE_BILLBOARD) {
 		for (int i = begin; i < end; i++) {
-			struct billboard_texture *bt = RE_renderer_load_billboard_texture(motion->instance->plugin->renderer, i);
-			if (!bt)
+			if (!RE_renderer_load_billboard_texture(motion->instance->plugin->renderer, i))
 				return false;
-			if (bt->has_alpha)
-				motion->instance->is_transparent = true;
 		}
 	}
 	return true;


### PR DESCRIPTION
Before this, the order of drawing was determined on an instance-by- instance basis. Instances with even a single transparent material were drawn after fully opaque instances.

After this, first the opaque meshes in all instances are drawn, and then the transparent meshes are drawn from the nearest to the farthest.