### PR TITLE
Do not use ARCHIVE_MMAP on 32-bit systems

### DIFF
--- a/include/xsystem4.h
+++ b/include/xsystem4.h
@@ -69,6 +69,8 @@ void get_time(int *hour, int *min, int *sec, int *ms);
 #define XSYS4_DATA_DIR "/usr/local/share/xsystem4"
 #endif
 
+#define MMAP_IF_64BIT (sizeof(void*) >= 8 ? ARCHIVE_MMAP : 0)
+
 extern bool game_daibanchou_en;
 extern bool game_rance02_mg;
 extern bool game_rance6_mg;

--- a/src/3d/reign.c
+++ b/src/3d/reign.c
@@ -169,7 +169,7 @@ struct RE_plugin *RE_plugin_new(void)
 {
 	char *aar_path = gamedir_path("Data/ReignData.red");
 	int error = ARCHIVE_SUCCESS;
-	struct archive *aar = (struct archive *)aar_open(aar_path, ARCHIVE_MMAP, &error);
+	struct archive *aar = (struct archive *)aar_open(aar_path, MMAP_IF_64BIT, &error);
 	if (error == ARCHIVE_FILE_ERROR) {
 		WARNING("aar_open(\"%s\"): %s", display_utf0(aar_path), strerror(errno));
 	} else if (error == ARCHIVE_BAD_ARCHIVE_ERROR) {

--- a/src/asset_manager.c
+++ b/src/asset_manager.c
@@ -183,10 +183,10 @@ static bool afa_load_archive(struct asset_manager *_manager, const char *name)
 	snprintf(path, PATH_MAX, "%s.afa", name);
 
 	int error;
-	struct afa_archive *ar = afa_open(path, ARCHIVE_MMAP, &error);
+	struct afa_archive *ar = afa_open(path, MMAP_IF_64BIT, &error);
 	if (!ar) {
 		snprintf(path, PATH_MAX, "%s.AFA", name);
-		ar = afa_open(path, ARCHIVE_MMAP, &error);
+		ar = afa_open(path, MMAP_IF_64BIT, &error);
 		if (!ar) {
 			WARNING("Failed to open archive: %s", display_utf0(path));
 			return false;
@@ -324,7 +324,7 @@ static void ald_init(enum asset_type type, char **files, int count)
 		WARNING("Multiple asset archives for type %s", asset_strtype(type));
 
 	int error;
-	struct archive *ar = ald_open(files, count, ARCHIVE_MMAP, &error);
+	struct archive *ar = ald_open(files, count, MMAP_IF_64BIT, &error);
 	if (!ar)
 		ERROR("Failed to open ALD file: %s", archive_strerror(error));
 
@@ -343,7 +343,7 @@ static void afa_init(enum asset_type type, char *file)
 		WARNING("Multiple asset archives for type %s", asset_strtype(type));
 
 	int error;
-	struct afa_archive *ar = afa_open(file, ARCHIVE_MMAP, &error);
+	struct afa_archive *ar = afa_open(file, MMAP_IF_64BIT, &error);
 	if (!ar)
 		ERROR("Failed to open AFA file: %s", archive_strerror(error));
 

--- a/src/dungeon/dungeon.c
+++ b/src/dungeon/dungeon.c
@@ -99,7 +99,7 @@ static GLuint *load_event_textures(int *nr_textures_out)
 {
 	char *path = gamedir_path("Data/Event.alk");
 	int error = ARCHIVE_SUCCESS;
-	struct alk_archive *alk = alk_open(path, ARCHIVE_MMAP, &error);
+	struct alk_archive *alk = alk_open(path, MMAP_IF_64BIT, &error);
 	if (error == ARCHIVE_FILE_ERROR) {
 		WARNING("alk_open(\"%s\"): %s", display_utf0(path), strerror(errno));
 	} else if (error == ARCHIVE_BAD_ARCHIVE_ERROR) {
@@ -146,7 +146,7 @@ bool dungeon_load(struct dungeon_context *ctx, int num)
 	if (ctx->version == DRAW_DUNGEON_1) {
 		char *path = gamedir_path("Data/DungeonData.dlf");
 		int error = ARCHIVE_SUCCESS;
-		struct archive *dlf = (struct archive *)dlf_open(path, ARCHIVE_MMAP, &error);
+		struct archive *dlf = (struct archive *)dlf_open(path, MMAP_IF_64BIT, &error);
 		if (error == ARCHIVE_FILE_ERROR) {
 			WARNING("dlf_open(\"%s\"): %s", display_utf0(path), strerror(errno));
 		} else if (error == ARCHIVE_BAD_ARCHIVE_ERROR) {

--- a/src/hll/MonsterInfo.c
+++ b/src/hll/MonsterInfo.c
@@ -203,7 +203,7 @@ static bool MonsterInfo_Load(struct string *filename)
 {
 	char *path = gamedir_path("Data/ReignData.red");
 	int error = ARCHIVE_SUCCESS;
-	struct archive *aar = (struct archive *)aar_open(path, ARCHIVE_MMAP, &error);
+	struct archive *aar = (struct archive *)aar_open(path, MMAP_IF_64BIT, &error);
 	if (error == ARCHIVE_FILE_ERROR) {
 		WARNING("aar_open(\"%s\"): %s", display_utf0(path), strerror(errno));
 	} else if (error == ARCHIVE_BAD_ARCHIVE_ERROR) {


### PR DESCRIPTION
Some games have assets that are too large to mmap everything on a 32-bit address space. For example, TT3 has a total of 2.82GB of assets, which is too large for the 3GB address space limit of 32-bit Linux. On Android it's even stricter and mmaps of hundreds of MB can fail.