### PR TITLE
Use OpenGL ES by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,8 +14,8 @@ png = dependency('libpng')
 cglm = dependency('cglm', fallback : ['cglm', 'cglm_dep'])
 sndfile = dependency('sndfile')
 
-if get_option('use_gles')
-    gles = dependency('glesv2')
+gles = dependency('glesv2', version : '>=3', required: get_option('opengles'))
+if gles.found()
     gl_deps = [gles]
     add_project_arguments('-DUSE_GLES', language : 'c')
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
 option('debugger', type : 'feature', value : 'auto')
-option('use_gles', type : 'boolean', value : false, description : 'Target OpenGL ES 3.0')
+option('opengles', type : 'feature', value : 'auto', description : 'Target OpenGL ES 3.0')


### PR DESCRIPTION
This replaces `use_gles` boolean build option with `opengles` feature option. If OpenGL ES3 is available, it is preferred over desktop OpenGL. This can be overridden by `-Dopengles=disabled` meson flag.

This would help to catch problems like #93 early.