### PR TITLE
Windows: Fix read_save_file

### DIFF
--- a/src/savedata.c
+++ b/src/savedata.c
@@ -280,7 +280,7 @@ static cJSON *read_save_file(const char *filename)
 	char *buf;
 	char *path = savedir_path(filename);
 
-	if (!(f = file_open_utf8(path, "r"))) {
+	if (!(f = file_open_utf8(path, "rb"))) {
 		WARNING("Failed to open save file: %s: %s", display_utf0(filename), strerror(errno));
 		free(path);
 		return NULL;


### PR DESCRIPTION
This fixes an issue where saved files could not be read on Windows.

On Windows if a file is opened in text mode, `ftell()` at EOF returns the file size in bytes, but `fread()` tries to read the specified number of characters (after removing carriage returns), resulting in an EOF error.

To avoid this problem, open save files in binary mode.