### PR TITLE
Enter debugger REPL on middle-button click

### DIFF
--- a/include/debugger.h
+++ b/include/debugger.h
@@ -46,6 +46,7 @@ struct dbg_cmd {
 };
 
 extern bool dbg_enabled;
+extern bool dbg_start_in_debugger;
 extern unsigned dbg_current_frame;
 
 void dbg_init(void);

--- a/src/debug.c
+++ b/src/debug.c
@@ -37,6 +37,7 @@
 #include "xsystem4.h"
 
 bool dbg_enabled = true;
+bool dbg_start_in_debugger = false;
 unsigned dbg_current_frame = 0;
 static jmp_buf dbg_continuation;
 

--- a/src/input.c
+++ b/src/input.c
@@ -23,6 +23,7 @@
 #include "input.h"
 #include "scene.h"
 #include "vm.h"
+#include "debugger.h"
 
 #ifndef M_PI
 #define M_PI (3.14159265358979323846)
@@ -217,6 +218,10 @@ static void mouse_event(SDL_MouseButtonEvent *e)
 	enum sact_keycode code = sdl_to_sact_button(e->button);
 	if (code)
 		key_state[code] = e->state == SDL_PRESSED;
+#ifdef DEBUGGER_ENABLED
+	if (e->button == SDL_BUTTON_MIDDLE && e->state == SDL_PRESSED && dbg_start_in_debugger)
+		dbg_repl();
+#endif
 }
 
 #define JOYAXIS_DEADZONE 13500

--- a/src/system4.c
+++ b/src/system4.c
@@ -402,9 +402,6 @@ int main(int argc, char *argv[])
 	char *ainfile;
 	int err = AIN_SUCCESS;
 	bool audit = false;
-#ifdef DEBUGGER_ENABLED
-	bool start_in_debugger = false;
-#endif
 
 	char *font_mincho = NULL;
 	char *font_gothic = NULL;
@@ -482,7 +479,7 @@ int main(int argc, char *argv[])
 			dbg_enabled = false;
 			break;
 		case LOPT_DEBUG:
-			start_in_debugger = true;
+			dbg_start_in_debugger = true;
 			break;
 #endif
 		}
@@ -548,7 +545,7 @@ int main(int argc, char *argv[])
 
 #ifdef DEBUGGER_ENABLED
 	dbg_init();
-	if (start_in_debugger)
+	if (dbg_start_in_debugger)
 		dbg_repl();
 #endif
 


### PR DESCRIPTION
Effective only if `--debug` command line flag is specified.

I've been using this for a while and found it very useful, because I could use `bt` command to check the code location or `scene` to examine the scene graph anytime.

What do you think?