### PR TITLE
Add error checking for movie format

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -115,6 +115,12 @@ struct movie_context *movie_load(const char *filename)
 		movie_free(mc);
 		return NULL;
 	}
+	if (!plm_has_headers(mc->plm)) {
+		WARNING("%s: not a MPEG-PS file", path);
+		free(path);
+		movie_free(mc);
+		return NULL;
+	}
 	free(path);
 
 	if (!movie_shader.program)


### PR DESCRIPTION
AliceSoft only uses MPEG-PS, but PlayMovie.dll is included in System4 SDK and can play any format supported by DirectShow. This fixes crash in `movie_load()` when given file was not a MPEG-PS.