### PR TITLE
Add vm_sleep()

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -106,6 +106,7 @@ union vm_value vm_copy(union vm_value v, enum ain_data_type type);
 int vm_execute_ain(struct ain *program);
 void vm_call(int fno, int struct_page);
 int vm_time(void);
+void vm_sleep(int ms);
 
 void hll_call(int libno, int fno);
 bool library_exists(int libno);

--- a/src/hll/InputDevice.c
+++ b/src/hll/InputDevice.c
@@ -14,12 +14,11 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-#include <time.h>
-
 #include "system4/string.h"
 
 #include "hll.h"
 #include "input.h"
+#include "vm.h"
 
 static void handle_events_throttled(void)
 {
@@ -28,11 +27,7 @@ static void handle_events_throttled(void)
 	static int count;
 	if (++count == 30) {
 		count = 0;
-		struct timespec ts = {
-			.tv_sec = 0,
-			.tv_nsec = 10000000L
-		};
-		nanosleep(&ts, NULL);
+		vm_sleep(10);
 	}
 	handle_events();
 }

--- a/src/hll/Timer.c
+++ b/src/hll/Timer.c
@@ -17,6 +17,7 @@
 #include <time.h>
 
 #include "hll.h"
+#include "vm.h"
 
 HLL_WARN_UNIMPLEMENTED(1, int, Timer, Init, void *imainsystem);
 
@@ -28,11 +29,7 @@ static int Timer_Get(void)
 
 static void Timer_Wait(int time)
 {
-	struct timespec ts = {
-		.tv_sec = time / 1000,
-		.tv_nsec = (time % 1000) * 1000000L
-	};
-	nanosleep(&ts, NULL);
+	vm_sleep(time);
 }
 
 static void Timer_GetDayTime(int *year, int *month, int *day_of_week, int *day,

--- a/src/vm.c
+++ b/src/vm.c
@@ -570,11 +570,7 @@ static void system_call(enum syscall_code code)
 	}
 	case SYS_SLEEP: {// system.Sleep(int nSleep)
 		int ms = stack_pop().i;
-		struct timespec ts = {
-			.tv_sec = ms / 1000,
-			.tv_nsec = (ms % 1000) * 1000000L
-		};
-		nanosleep(&ts, NULL);
+		vm_sleep(ms);
 		break;
 	}
 	case SYS_RESUME_READ_COMMENT: {// system.ResumeReadComment(string szKeyName, string szFileName, ref array@string aszComment)
@@ -2372,6 +2368,11 @@ int vm_time(void)
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	return (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+}
+
+void vm_sleep(int ms)
+{
+	SDL_Delay(ms);
 }
 
 _Noreturn void vm_exit(int code)


### PR DESCRIPTION
The `nanosleep()` function in mingw-w64 often sleeps for more than the specified time. This causes a problem in Rance 6 combat scene, where the damage popup is noticeably slow.

This adds `vm_sleep()` that calls `SDL_Delay()` which uses high-resolution timer on Windows.