### PR TITLE
sact_SP_TextDraw: Early return if sprite size is zero

### DIFF
--- a/src/hll/SACT2.c
+++ b/src/hll/SACT2.c
@@ -521,7 +521,7 @@ int _sact_SP_TextDraw(int sp_no, struct string *text, struct text_style *ts)
 	// XXX: In AliceSoft's implementation, this function succeeds even with
 	//      a negative sp_no...
 	struct sact_sprite *sp = sact_get_sprite(sp_no);
-	if (!sp) return 0;
+	if (!sp || !sp->rect.w || !sp->rect.h) return 0;
 	sprite_text_draw(sp, text, ts);
 	return 1;
 }


### PR DESCRIPTION
Otherwise it `ERROR()`s in `gfx_set_framebuffer()` due to an incomplete framebuffer.

This happens when trying to display text without specifying a message window in SACT2. AliceSoft's implementation ignores this.