### PR TITLE
StoatSpriteEngine: Clear cached font_size struct in SP_SetTextSpriteSize

### DIFF
--- a/src/hll/StoatSpriteEngine.c
+++ b/src/hll/StoatSpriteEngine.c
@@ -132,6 +132,8 @@ void StoatSpriteEngine_SP_SetTextSpriteType(int type)
 
 void StoatSpriteEngine_SP_SetTextSpriteSize(int size)
 {
+	if (text_sprite_ts.size != size)
+		text_sprite_ts.font_size = NULL;
 	text_sprite_ts.size = size;
 }
 


### PR DESCRIPTION
This fixes text layout issue in Daiteikoku and Rance Quest.

Before: ![before](https://github.com/nunuhara/xsystem4/assets/12679772/0c8f01d3-630c-4dad-b9ea-c4e098a885b8)

After:  ![after](https://github.com/nunuhara/xsystem4/assets/12679772/81da8dd0-22e8-4c12-ad82-2267681430b6)
