### PR TITLE
SystemService can only access mixers specified in ini

### DIFF
--- a/src/audio_mixer.c
+++ b/src/audio_mixer.c
@@ -666,19 +666,21 @@ void mixer_init(void)
 
 int mixer_get_numof(void)
 {
-	return nr_mixers;
+	// Return the number of mixers specified in System40.ini, even if
+	// xsystem4 added more mixers.
+	return config.mixer_nr_channels;
 }
 
 const char *mixer_get_name(int n)
 {
-	if (n < 0 || n >= nr_mixers)
+	if (n < 0 || n >= config.mixer_nr_channels)
 		return NULL;
 	return mixers[n].name;
 }
 
 int mixer_set_name(int n, const char *name)
 {
-	if (n < 0 || n >= nr_mixers)
+	if (n < 0 || n >= config.mixer_nr_channels)
 		return 0;
 	free(mixers[n].name);
 	mixers[n].name = strdup(name);
@@ -687,7 +689,7 @@ int mixer_set_name(int n, const char *name)
 
 int mixer_get_volume(int n, int *volume)
 {
-	if (n < 0 || n >= nr_mixers) {
+	if (n < 0 || n >= config.mixer_nr_channels) {
 		return 0;
 	}
 	SDL_LockAudioDevice(audio_device);
@@ -698,7 +700,7 @@ int mixer_get_volume(int n, int *volume)
 
 int mixer_set_volume(int n, int volume)
 {
-	if (n < 0 || n >= nr_mixers)
+	if (n < 0 || n >= config.mixer_nr_channels)
 		return 0;
 	SDL_LockAudioDevice(audio_device);
 	mixers[n].mixer.gain = clamp(0.0f, 1.0f, (float)volume / 100.0f);
@@ -707,7 +709,7 @@ int mixer_set_volume(int n, int volume)
 }
 int mixer_get_mute(int n, int *mute)
 {
-	if (n < 0 || n >= nr_mixers)
+	if (n < 0 || n >= config.mixer_nr_channels)
 		return 0;
 	*mute = mixers[n].muted;
 	return 1;
@@ -715,7 +717,7 @@ int mixer_get_mute(int n, int *mute)
 
 int mixer_set_mute(int n, int mute)
 {
-	if (n < 0 || n >= nr_mixers)
+	if (n < 0 || n >= config.mixer_nr_channels)
 		return 0;
 	mixers[n].muted = !!mute;
 	return 1;


### PR DESCRIPTION
This ensures that SystemService.hll mixer functions can only access mixers specified in System40.ini, even if xsystem4 added more mixers.

Beat Blades Haruka checks the number and names of mixers, and refuses to open the config screen if they are not as expected.