### PR TITLE
Fix path resolution in MsgSkip.Init

### DIFF
--- a/src/hll/MsgSkip.c
+++ b/src/hll/MsgSkip.c
@@ -60,7 +60,14 @@ static int MsgSkip_Init(struct string *name)
 	nr_flags = ain->nr_messages;
 	flags = xcalloc((nr_flags + 7) / 8, 1);
 
-	save_path = unix_path(name->text);
+	// Most games have system.GetSaveFolderName() prepended to `name`, but some
+	// games pass a constant string "SaveData\\MsgSkip.asd". If you pass it to
+	// savedir_path() as it is, "SaveData/" will be duplicated, so remove it.
+	if (!strncmp(name->text, "SaveData\\", 9)) {
+		save_path = savedir_path(name->text + 9);
+	} else {
+		save_path = savedir_path(name->text);
+	}
 
 	size_t data_size;
 	uint8_t *data = file_read(save_path, &data_size);


### PR DESCRIPTION
Some games (Ojou-sama o Iinari ni Suru Game and Double Sensei Life, as far as I know) pass "SaveData\\MsgSkip.asd" to MsgSkip.Init. So this change:

* uses savedir_path() to resolve the relative path, and
* removes the "SaveData\\" prefix, otherwise "SaveData/" will be duplicated in the resolved path.