### PR TITLE
DrawDungeon14: Implement raster effect

### DIFF
--- a/include/dungeon/dungeon.h
+++ b/include/dungeon/dungeon.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include "gfx/gl.h"
+#include "gfx/gfx.h"
 #include "plugin.h"
 
 struct page;
@@ -63,6 +63,7 @@ struct dungeon_context {
 	struct dtx *dtx;
 	struct tes *tes;
 	struct dungeon_renderer *renderer;
+	struct texture texture;
 	GLuint depth_buffer;
 };
 

--- a/include/dungeon/renderer.h
+++ b/include/dungeon/renderer.h
@@ -20,6 +20,7 @@
 #include <cglm/cglm.h>
 #include "gfx/gl.h"
 
+struct texture;
 struct dgn_cell;
 struct dtx;
 struct polyobj;
@@ -31,5 +32,8 @@ void dungeon_renderer_render(struct dungeon_renderer *r, struct dgn_cell **cells
 void dungeon_renderer_enable_event_markers(struct dungeon_renderer *r, bool enable);
 bool dungeon_renderer_event_markers_enabled(struct dungeon_renderer *r);
 bool dungeon_renderer_is_floor_opaque(struct dungeon_renderer *r, struct dgn_cell *cell);
+void dungeon_renderer_run_post_processing(struct dungeon_renderer *r, struct texture *src, struct texture *dst);
+void dungeon_renderer_set_raster_scroll(struct dungeon_renderer *r, int type);
+void dungeon_renderer_set_raster_amp(struct dungeon_renderer *r, float amp);
 
 #endif /* SYSTEM4_DUNGEON_RENDERER_H */

--- a/include/gfx/gfx.h
+++ b/include/gfx/gfx.h
@@ -154,6 +154,7 @@ void gfx_copy_rot_zoom_amap(Texture *dst, Texture *src, int sx, int sy, int w, i
 void gfx_copy_rot_zoom_use_amap(Texture *dst, Texture *src, int sx, int sy, int w, int h, float rotate, float mag);
 void gfx_copy_root_zoom2(Texture *dst, float cx, float cy, Texture *src, float scx, float scy, float rot, float mag);
 void gfx_copy_reverse_LR(Texture *dst, int dx, int dy, Texture *src, int sx, int sy, int w, int h);
+void gfx_copy_reverse_UD(Texture *dst, int dx, int dy, Texture *src, int sx, int sy, int w, int h);
 void gfx_copy_reverse_amap_LR(Texture *dst, int dx, int dy, Texture *src, int sx, int sy, int w, int h);
 void gfx_copy_rotate_y(Texture *dst, Texture *front, Texture *back, int sx, int sy, int w, int h, float rot, float mag);
 void gfx_copy_rotate_y_use_amap(Texture *dst, Texture *front, Texture *back, int sx, int sy, int w, int h, float rot, float mag);

--- a/shaders/dungeon_raster.f.glsl
+++ b/shaders/dungeon_raster.f.glsl
@@ -1,0 +1,39 @@
+/* Copyright (C) 2023 kichikuou <KichikuouChrome@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://gnu.org/licenses/>.
+ */
+
+uniform sampler2D tex;
+
+uniform float amp;
+uniform float t;
+
+const float PI = 3.14159265;
+
+in vec2 tex_coord;
+out vec4 frag_color;
+
+vec4 sample(float offset_x) {
+	return texture(tex, vec2(tex_coord.x + offset_x, tex_coord.y));
+}
+
+void main() {
+	float a = amp * cos((tex_coord.y + fract(t / 8.0)) * 16.0 * PI);
+	float p1 = 6.0 * tex_coord.y + 1.5;
+	float p2 = 4.0 * tex_coord.y + 2.0;
+	float offset1 = cos(p1 * 2.0 * PI) * a;
+	float offset2 = cos(p2 * 2.0 * PI) * a;
+
+	frag_color = mix(sample(offset1), sample(offset2), 0.5);
+}

--- a/src/draw.c
+++ b/src/draw.c
@@ -891,6 +891,23 @@ void gfx_copy_reverse_LR(Texture *dst, int dx, int dy, Texture *src, int sx, int
 	restore_blend_mode();
 }
 
+void gfx_copy_reverse_UD(Texture *dst, int dx, int dy, Texture *src, int sx, int sy, int w, int h)
+{
+	mat4 mw_transform = MAT4(
+	     src->w, 0,       0, -sx,
+	     0,      -src->h, 0, sy + h,
+	     0,      0,       1, 0,
+	     0,      0,       0, 1);
+	mat4 wv_transform = WV_TRANSFORM(w, h);
+
+	glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ZERO, GL_ONE);
+
+	struct copy_data data = COPY_DATA(dx, dy, sx, sy, w, h);
+	run_draw_shader(&copy_shader.s, dst, src, mw_transform, wv_transform, &data);
+
+	restore_blend_mode();
+}
+
 void gfx_copy_reverse_amap_LR(Texture *dst, int dx, int dy, Texture *src, int sx, int sy, int w, int h)
 {
 	mat4 mw_transform = MAT4(

--- a/src/hll/DrawDungeon.c
+++ b/src/hll/DrawDungeon.c
@@ -267,7 +267,8 @@ HLL_QUIET_UNIMPLEMENTED(1, bool, DrawDungeon, IsDrawSettingFile, void);
 HLL_QUIET_UNIMPLEMENTED( , void, DrawDungeon, DeleteDrawSettingFile, void);
 HLL_QUIET_UNIMPLEMENTED(1, bool, DrawDungeon, IsSSEFlag, void);
 HLL_QUIET_UNIMPLEMENTED( , void, DrawDungeon, SetSSEFlag, bool flag);
-bool DrawDungeon_IsPVSData(int surface)
+
+static bool DrawDungeon_IsPVSData(int surface)
 {
 	return false;
 }
@@ -408,11 +409,26 @@ HLL_LIBRARY(DrawDungeon,
 	    DRAW_DUNGEON_EXPORTS
 	    );
 
-HLL_WARN_UNIMPLEMENTED( , void, DrawDungeon14, SetRasterScroll, int surface, int type);
-HLL_WARN_UNIMPLEMENTED( , void, DrawDungeon14, SetRasterAmp, int nSurface, float fAmp);
+static void DrawDungeon14_SetRasterScroll(int surface, int type)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->renderer)
+		return true;
+	return dungeon_renderer_set_raster_scroll(ctx->renderer, type);
+}
+
+static void DrawDungeon14_SetRasterAmp(int surface, float amp)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->renderer)
+		return true;
+	return dungeon_renderer_set_raster_amp(ctx->renderer, amp);
+}
+
+// unused
 HLL_WARN_UNIMPLEMENTED( , void, DrawDungeon14, SetLapFilter, int surface, int type, int r, int g, int b);
 
-bool DrawDungeon14_GetDrawMapObjectFlag(int surface)
+static bool DrawDungeon14_GetDrawMapObjectFlag(int surface)
 {
 	struct dungeon_context *ctx = dungeon_get_context(surface);
 	if (!ctx || !ctx->renderer)
@@ -420,7 +436,7 @@ bool DrawDungeon14_GetDrawMapObjectFlag(int surface)
 	return dungeon_renderer_event_markers_enabled(ctx->renderer);
 }
 
-void DrawDungeon14_SetDrawMapObjectFlag(int surface, bool flag)
+static void DrawDungeon14_SetDrawMapObjectFlag(int surface, bool flag)
 {
 	struct dungeon_context *ctx = dungeon_get_context(surface);
 	if (!ctx || !ctx->renderer)

--- a/src/hll/DrawGraph.c
+++ b/src/hll/DrawGraph.c
@@ -338,7 +338,10 @@ static void DrawGraph_CopyReverseLR(int dst, int dx, int dy, int src, int sx, in
 	gfx_copy_reverse_LR(DTEX(dst), dx, dy, STEX(src), sx, sy, w, h);
 }
 
-//void DrawGraph_CopyReverseUD(int dst, int dx, int dy, int src, int sx, int sy, int w, int h);
+static void DrawGraph_CopyReverseUD(int dst, int dx, int dy, int src, int sx, int sy, int w, int h)
+{
+	gfx_copy_reverse_UD(DTEX(dst), dx, dy, STEX(src), sx, sy, w, h);
+}
 
 static void DrawGraph_CopyReverseAMapLR(int dst, int dx, int dy, int src, int sx, int sy, int w, int h)
 {
@@ -495,7 +498,7 @@ HLL_LIBRARY(DrawGraph,
 	    //HLL_EXPORT(CopyRotateXFixUUseAMap, DrawGraph_CopyRotateXFixUUseAMap),
 	    //HLL_EXPORT(CopyRotateXFixDUseAMap, DrawGraph_CopyRotateXFixDUseAMap),
 	    HLL_EXPORT(CopyReverseLR, DrawGraph_CopyReverseLR),
-	    //HLL_EXPORT(CopyReverseUD, DrawGraph_CopyReverseUD),
+	    HLL_EXPORT(CopyReverseUD, DrawGraph_CopyReverseUD),
 	    HLL_EXPORT(CopyReverseAMapLR, DrawGraph_CopyReverseAMapLR),
 	    //HLL_EXPORT(CopyReverseAMapUD, DrawGraph_CopyReverseAMapUD),
 	    HLL_EXPORT(CopyWidthBlur, DrawGraph_CopyWidthBlur),

--- a/src/hll/Gpx2Plus.c
+++ b/src/hll/Gpx2Plus.c
@@ -372,7 +372,14 @@ static void Gpx2Plus_CopyReverseLR(int destSurface, int dx, int dy, int srcSurfa
 	gfx_copy_reverse_LR(dst, dx, dy, src, sx, sy, width, height);
 }
 
-// void CopyReverseUD(int nDestSurface, int nDx, int nDy, int nSrcSurface, int nSx, int nSy, int nWidth, int nHeight);
+static void Gpx2Plus_CopyReverseUD(int destSurface, int dx, int dy, int srcSurface, int sx, int sy, int width, int height)
+{
+	struct texture *dst = get_texture(destSurface);
+	struct texture *src = get_texture(srcSurface);
+	if (!dst || !src)
+		return;
+	gfx_copy_reverse_UD(dst, dx, dy, src, sx, sy, width, height);
+}
 
 static void Gpx2Plus_CopyReverseAMapLR(int destSurface, int dx, int dy, int srcSurface, int sx, int sy, int width, int height)
 {
@@ -745,7 +752,7 @@ HLL_LIBRARY(Gpx2Plus,
 			HLL_EXPORT(CopyStretchReduce, Gpx2Plus_CopyStretchReduce),
 			HLL_EXPORT(CopyStretchReduceAMap, Gpx2Plus_CopyStretchReduceAMap),
 			HLL_EXPORT(CopyReverseLR, Gpx2Plus_CopyReverseLR),
-			// HLL_EXPORT(CopyReverseUD, Gpx2Plus_CopyReverseUD),
+			HLL_EXPORT(CopyReverseUD, Gpx2Plus_CopyReverseUD),
 			HLL_EXPORT(CopyReverseAMapLR, Gpx2Plus_CopyReverseAMapLR),
 			// HLL_EXPORT(CopyReverseAMapUD, Gpx2Plus_CopyReverseAMapUD),
 			// HLL_EXPORT(BlendScreenWDS, Gpx2Plus_BlendScreenWDS),


### PR DESCRIPTION
It is implemented as a post-processing effect. The hack for the projection transform matrix has been removed, because now the image is flipped upside down in the post-processing stage.