### PR TITLE
Fix S_MOD for bool and long int

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -114,7 +114,16 @@ bool library_function_exists(int libno, int fno);
 void init_libraries(void);
 void exit_libraries(void);
 
-struct string *string_format(struct string *fmt, union vm_value arg, enum ain_data_type type);
+// NOTE: This can probably be merged with ain_data_type, since the values are
+// disjoint.
+enum string_format_type {
+	STRFMT_INT = 2,
+	STRFMT_FLOAT = 3,
+	STRFMT_STRING = 4,
+	STRFMT_BOOL = 48,
+	STRFMT_LONG_INT = 56,
+};
+struct string *string_format(struct string *fmt, union vm_value arg, enum string_format_type type);
 
 void vm_stack_trace(void);
 _Noreturn void _vm_error(const char *fmt, ...);

--- a/src/hll/DrawDungeon.c
+++ b/src/hll/DrawDungeon.c
@@ -413,7 +413,7 @@ static void DrawDungeon14_SetRasterScroll(int surface, int type)
 {
 	struct dungeon_context *ctx = dungeon_get_context(surface);
 	if (!ctx || !ctx->renderer)
-		return true;
+		return;
 	return dungeon_renderer_set_raster_scroll(ctx->renderer, type);
 }
 
@@ -421,7 +421,7 @@ static void DrawDungeon14_SetRasterAmp(int surface, float amp)
 {
 	struct dungeon_context *ctx = dungeon_get_context(surface);
 	if (!ctx || !ctx->renderer)
-		return true;
+		return;
 	return dungeon_renderer_set_raster_amp(ctx->renderer, amp);
 }
 

--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -1008,7 +1008,7 @@ bool PE_SetLoopCG_by_index(int parts_no, int cg_no, int nr_frames, int frame_tim
 static struct cg *load_loop_cg_by_name(int no, void *data)
 {
 	int unused_no;
-	struct string *cg_name = string_format((struct string*)data, (union vm_value){.i=no}, AIN_INT);
+	struct string *cg_name = string_format((struct string*)data, (union vm_value){.i=no}, STRFMT_INT);
 	struct cg *cg = asset_cg_load_by_name(cg_name->text, &unused_no);
 	free_string(cg_name);
 	return cg;

--- a/src/vm.c
+++ b/src/vm.c
@@ -1532,7 +1532,7 @@ static enum opcode execute_instruction(enum opcode opcode)
 		union vm_value val = stack_pop();
 		int fmt = stack_pop().i;
 		int dst = heap_alloc_slot(VM_STRING);
-		heap[dst].s = string_format(heap[fmt].s, val, type + 8);
+		heap[dst].s = string_format(heap[fmt].s, val, type);
 		heap_unref(fmt);
 		stack_push(dst);
 		break;

--- a/test/Source/strings.jaf
+++ b/test/Source/strings.jaf
@@ -5,6 +5,7 @@ void test_strings(void)
 	int i;
 	float f;
 	string s;
+	bool b;
 	test_bool("\"a\" == \"a\"", "a" == "a", true);
 	test_bool("\"a\" != \"b\"", "a" == "b", false);
 	test_bool("\"a\" < \"b\"",  "a" < "b",  true);
@@ -86,8 +87,10 @@ void test_strings(void)
 	// char
 	test_string("abc%cdef % '‚ '", "abc%cdef" % '‚ ', "abc‚ def");
 	// bool
-	test_string("abc%bdef % 1", "abc%bdef" % 1, "abctruedef");
-	test_string("abc%bdef % 0", "abc%bdef" % 0, "abcfalsedef");
+	test_string("abc%bdef % 1", "abc%bdef" % (b = 1), "abctruedef");
+	test_string("abc%bdef % 0", "abc%bdef" % (b = 0), "abcfalsedef");
+	// type mismatch
+	test_string("%s % 42", "%s" % 42, "%s");
 
 	// I_STRING
 	test_bool("(42).String()", (i = 42, i.String() == "42"), true);


### PR DESCRIPTION
* The "type" argument of `S_MOD` is 48 for bool, 56 for long int
* `%b`, `%c`, `%d` can consume any integer types (int, bool, or long int)
* If the value cannot be consumed, `S_MOD` should return the format string instead of an empty string

This also fixes incorrect return types in DrawDungeon14, introduced by #134.