### PR TITLE
Fix a bug that bgm did not work after movie load failed

### DIFF
--- a/src/movie_ffmpeg.c
+++ b/src/movie_ffmpeg.c
@@ -209,6 +209,7 @@ static int audio_callback(sts_mixer_sample_t *sample, void *data)
 struct movie_context *movie_load(const char *filename)
 {
 	struct movie_context *mc = xcalloc(1, sizeof(struct movie_context));
+	mc->voice = -1;
 	char *path = gamedir_path(filename);
 	int ret;
 	if ((ret = avformat_open_input(&mc->format_ctx, path, NULL, NULL)) != 0) {
@@ -257,7 +258,6 @@ struct movie_context *movie_load(const char *filename)
 
 	mc->format_mutex = SDL_CreateMutex();
 	mc->timer_mutex = SDL_CreateMutex();
-	mc->voice = -1;
 	mc->volume = 100;
 
 	preload_packets(mc);

--- a/src/movie_plmpeg.c
+++ b/src/movie_plmpeg.c
@@ -111,6 +111,7 @@ static void update_texture(GLuint unit, GLuint texture, plm_plane_t *plane)
 struct movie_context *movie_load(const char *filename)
 {
 	struct movie_context *mc = xcalloc(1, sizeof(struct movie_context));
+	mc->voice = -1;
 	char *path = gamedir_path(filename);
 	FILE *fp = file_open_utf8(path, "rb");
 	if (!fp) {
@@ -142,7 +143,6 @@ struct movie_context *movie_load(const char *filename)
 
 	mc->decoder_mutex = SDL_CreateMutex();
 	mc->timer_mutex = SDL_CreateMutex();
-	mc->voice = -1;
 	mc->volume = 100;
 	return mc;
 }


### PR DESCRIPTION
When movie_free() was called in movie_load(), mixer_stream_stop(0) was mistakenly called and the music mixer was stopped.