### PR TITLE
BanMisc: Use the same save format as AliceSoft's implementation

### DIFF
--- a/src/hll/AnteaterADVEngine.c
+++ b/src/hll/AnteaterADVEngine.c
@@ -314,7 +314,7 @@ bool ADVSceneKeeper_AddADVScene(struct page **page)
 	// serialize
 	struct iarray_writer out;
 	iarray_init_writer(&out, "SCN");
-	iarray_write_struct(&out, *page);
+	iarray_write_struct(&out, *page, false);
 	scenes.data[scenes.n++] = iarray_to_page(&out);
 	iarray_free_writer(&out);
 
@@ -341,7 +341,7 @@ bool ADVSceneKeeper_GetADVScene(int index, struct page **page)
 		free_page(*page);
 	}
 
-	*page = iarray_read_struct(&in, scene_struct_no());
+	*page = iarray_read_struct(&in, scene_struct_no(), false);
 	return !in.error;
 }
 

--- a/src/hll/ChrLoader.c
+++ b/src/hll/ChrLoader.c
@@ -95,10 +95,7 @@ static uint8_t *chr_get(int id)
 		free(data);
 		data = NULL;
 	} else {
-		struct mt19937 mt;
-		mt19937_init(&mt, 12753);
-		for (size_t i = 4; i < size; i++)
-			data[i] ^= mt19937_genrand(&mt);
+		mt19937_xorcode(data + 4, size - 4, 12753);
 		slot->value = data;
 	}
 	free(path);

--- a/src/hll/DataFile.c
+++ b/src/hll/DataFile.c
@@ -274,10 +274,7 @@ static int DataFile_Open(int link)
 	uint8_t *compressed_data = xmalloc(compressed_size);
 	buffer_read_bytes(&r, compressed_data, compressed_size);
 	archive_free_data(dfile);
-	struct mt19937 mt;
-	mt19937_init(&mt, 4588163);
-	for (size_t i = 0; i < compressed_size; i++)
-		compressed_data[i] ^= mt19937_genrand(&mt);
+	mt19937_xorcode(compressed_data, compressed_size, 4588163);
 
 	uint8_t *raw = xmalloc(uncompressed_size);
 	int rv = uncompress(raw, &uncompressed_size, compressed_data, compressed_size);

--- a/src/hll/MapLoader.c
+++ b/src/hll/MapLoader.c
@@ -95,10 +95,7 @@ static bool MapLoader_Load(int map_no)
 		free(map_data);
 		map_data = NULL;
 	} else {
-		struct mt19937 mt;
-		mt19937_init(&mt, 12753);
-		for (size_t i = 4; i < map_size; i++)
-			map_data[i] ^= mt19937_genrand(&mt);
+		mt19937_xorcode(map_data + 4, map_size - 4, 12753);
 	}
 	free(path);
 	return !!map_data;

--- a/src/hll/iarray.h
+++ b/src/hll/iarray.h
@@ -40,7 +40,7 @@ void iarray_write_at(struct iarray_writer *w, unsigned pos, int data);
 void iarray_write_float(struct iarray_writer *w, float data);
 void iarray_write_string(struct iarray_writer *w, struct string *s);
 void iarray_write_string_or_null(struct iarray_writer *w, struct string *s);
-void iarray_write_struct(struct iarray_writer *w, struct page *page);
+void iarray_write_struct(struct iarray_writer *w, struct page *page, bool with_type);
 void iarray_write_array(struct iarray_writer *w, struct page *page);
 void iarray_write_point(struct iarray_writer *w, Point *p);
 void iarray_write_rectangle(struct iarray_writer *w, Rectangle *r);
@@ -53,6 +53,7 @@ static inline unsigned iarray_writer_pos(struct iarray_writer *w)
 }
 
 struct page *iarray_to_page(struct iarray_writer *w);
+uint8_t *iarray_to_buffer(struct iarray_writer *w, size_t *size_out);
 
 struct iarray_reader {
 	union vm_value *data;
@@ -71,7 +72,7 @@ int iarray_read(struct iarray_reader *r);
 float iarray_read_float(struct iarray_reader *r);
 struct string *iarray_read_string(struct iarray_reader *r);
 struct string *iarray_read_string_or_null(struct iarray_reader *r);
-struct page *iarray_read_struct(struct iarray_reader *r, int struct_type);
+struct page *iarray_read_struct(struct iarray_reader *r, int struct_type, bool with_type);
 struct page *iarray_read_array(struct iarray_reader *r, struct ain_type *t);
 void iarray_read_point(struct iarray_reader *r, Point *p);
 void iarray_read_rectangle(struct iarray_reader *r, Rectangle *rect);


### PR DESCRIPTION
BanMisc.{Save,Load}Struct now serializes structs in the same format as AliceSoft's implementation, rather than in JSON format. The old JSON format can also be loaded for backwards compatibility.

Fixes #140.