### PR TITLE
system.GetTime(): Use SDL_GetTicks() instead of clock_gettime()

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2383,9 +2383,7 @@ _Noreturn void _vm_error(const char *fmt, ...)
 
 int vm_time(void)
 {
-	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+	return SDL_GetTicks();
 }
 
 void vm_sleep(int ms)


### PR DESCRIPTION
Some games (e.g. Toushin Toshi 3) malfunction when `system.GetTime()` returns a negative number.

On many systems `clock_gettime(CLOCK_MONOTONIC)` returns the time since OS startup, but this wraps to a negative number (in signed 32-bit integer) after about 24.8 days.

As a mitigation, use `SDL_GetTicks()` instead, which returns the elapsed time since game startup.