### PR TITLE
File.Read/Write: Use the same format as AliceSoft's implementation

### DIFF
--- a/include/savedata.h
+++ b/include/savedata.h
@@ -20,10 +20,7 @@
 #include "cJSON.h"
 #include "vm.h"
 
-cJSON *page_to_json(struct page *page);
-cJSON *vm_value_to_json(enum ain_data_type type, union vm_value val);
 void json_load_page(struct page *page, cJSON *vars, bool call_dtors);
-union vm_value json_to_vm_value(enum ain_data_type type, enum ain_data_type struct_type, int array_rank, cJSON *json);
 
 int save_json(const char *filename, cJSON *json);
 int save_globals(const char *keyname, const char *filename, const char *group_name, int *n);


### PR DESCRIPTION
This improves interoperability of save files in Rance6, GALZOO, etc. The old JSON format can still be loaded for backwards compatibility.