### PR TITLE
PassRegister: Use the same format as AliceSoft's implementation

### DIFF
--- a/src/hll/PassRegister.c
+++ b/src/hll/PassRegister.c
@@ -15,21 +15,46 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <zlib.h>
 #include "cJSON.h"
 
 #include "system4.h"
+#include "system4/buffer.h"
 #include "system4/string.h"
 #include "system4/file.h"
 
 #include "hll.h"
+#include "little_endian.h"
 #include "xsystem4.h"
 
 /*
  * Special SaveData API for savings sets of integers and strings
  * (e.g. unlocked CGs).
+ *
+ * The data is stored in a file with the following format:
+ *
+ * struct psr_file {
+ *     char     magic[4];               // "PSR\0"
+ *     uint32_t version;                // must be 0
+ *     uint32_t raw_size;               // size of the uncompressed data
+ *     uint32_t compressed_size;        // size of the compressed data
+ *     uint8_t  data[compressed_size];  // ZLIB-compressed data
+ * };
+ *
+ * The uncompressed data is a structure of the following form:
+ *
+ * struct psr_data {
+ *     uint32_t nr_integers;
+ *     int32_t  integers[nr_integers];
+ *     uint32_t nr_strings;
+ *     char     strings[nr_strings][?];  // null-terminated strings
+ * };
  */
+
+#define PSR_HEADER_SIZE 16
 
 struct passregister {
 	char *filename;
@@ -42,23 +67,12 @@ struct passregister {
 static size_t nr_registers = 0;
 static struct passregister *registers = NULL;
 
-static cJSON *register_to_json(unsigned handle)
-{
-	struct passregister *reg = registers + handle;
-	cJSON *obj = cJSON_CreateObject();
-	cJSON *integers = cJSON_CreateArray();
-	cJSON *strings = cJSON_CreateArray();
+static int compare_int(const void *a, const void *b) {
+    return (*(int*)a - *(int*)b);
+}
 
-	for (size_t i = 0; i < reg->nr_integers; i++) {
-		cJSON_AddItemToArray(integers, cJSON_CreateNumber(reg->integers[i]));
-	}
-	for (size_t i = 0; i < reg->nr_strings; i++) {
-		cJSON_AddItemToArray(strings, cJSON_CreateString(reg->strings[i]));
-	}
-
-	cJSON_AddItemToObject(obj, "integers", integers);
-	cJSON_AddItemToObject(obj, "strings", strings);
-	return obj;
+static int compare_string(const void *a, const void *b) {
+    return strcmp(*(const char **)a, *(const char **)b);
 }
 
 static void write_register(unsigned handle)
@@ -71,19 +85,43 @@ static void write_register(unsigned handle)
 		return;
 	}
 
-	cJSON *json = register_to_json(handle);
-	char *str = cJSON_Print(json);
-	if (fwrite(str, strlen(str), 1, f) != 1) {
+	// Sort the arrays for compatibility with AliceSoft's implementation.
+	qsort(reg->integers, reg->nr_integers, sizeof(int), compare_int);
+	qsort(reg->strings, reg->nr_strings, sizeof(char*), compare_string);
+
+	struct buffer buf;
+	buffer_init(&buf, NULL, 0);
+	buffer_write_int32(&buf, reg->nr_integers);
+	for (size_t i = 0; i < reg->nr_integers; i++) {
+		buffer_write_int32(&buf, reg->integers[i]);
+	}
+	buffer_write_int32(&buf, reg->nr_strings);
+	for (size_t i = 0; i < reg->nr_strings; i++) {
+		buffer_write_cstringz(&buf, reg->strings[i]);
+	}
+
+	size_t raw_size = buf.index;
+	unsigned long compressed_size = compressBound(raw_size);
+	uint8_t *compressed = xmalloc(compressed_size);
+	int r = compress2(compressed, &compressed_size, buf.buf, raw_size, Z_BEST_COMPRESSION);
+	if (r != Z_OK) {
+		WARNING("Failed to compress PassRegister file: %s", display_utf0(reg->filename));
+		goto end;
+	}
+	uint8_t header[PSR_HEADER_SIZE] = {'P', 'S', 'R', 0, 0, 0, 0, 0};
+	LittleEndian_putDW(header, 8, raw_size);
+	LittleEndian_putDW(header, 12, compressed_size);
+	if (fwrite(header, sizeof(header), 1, f) != 1 || fwrite(compressed, compressed_size, 1, f) != 1) {
 		WARNING("Failed to write PassRegister file: %s: %s", display_utf0(reg->filename), strerror(errno));
 		goto end;
 	}
+end:
+	free(compressed);
+	free(buf.buf);
 	if (fclose(f)) {
 		WARNING("Error writing to save file: %s: %s", display_utf0(reg->filename), strerror(errno));
 		goto end;
 	}
-end:
-	free(str);
-	cJSON_Delete(json);
 }
 
 static cJSON *_type_check(const char *file, const char *func, int line, int type, cJSON *json)
@@ -95,6 +133,66 @@ static cJSON *_type_check(const char *file, const char *func, int line, int type
 
 #define type_check(type, json) _type_check(__FILE__, __func__, __LINE__, type, json)
 
+static void read_register_psr(struct passregister *reg, uint8_t *data, size_t data_len)
+{
+	int version = LittleEndian_getDW(data, 4);
+	if (version != 0) {
+		WARNING("Unexpected PassRegister version %d", version);
+		return;
+	}
+	unsigned long raw_size = LittleEndian_getDW(data, 8);
+	size_t compressed_size = LittleEndian_getDW(data, 12);
+	if (PSR_HEADER_SIZE + compressed_size != data_len) {
+		WARNING("Broken PassRegister file");
+		return;
+	}
+	uint8_t *raw = xmalloc(raw_size);
+	int r = uncompress(raw, &raw_size, data + PSR_HEADER_SIZE, compressed_size);
+	if (r != Z_OK) {
+		WARNING("PassRegister: failed to uncompress");
+		free(raw);
+		return;
+	}
+
+	struct buffer buf;
+	buffer_init(&buf, raw, raw_size);
+	reg->nr_integers = buffer_read_int32(&buf);
+	reg->integers = xcalloc(reg->nr_integers, sizeof(int));
+	for (size_t i = 0; i < reg->nr_integers; i++) {
+		reg->integers[i] = buffer_read_int32(&buf);
+	}
+	reg->nr_strings = buffer_read_int32(&buf);
+	reg->strings = xcalloc(reg->nr_strings, sizeof(char*));
+	for (size_t i = 0; i < reg->nr_strings; i++) {
+		reg->strings[i] = strdup(buffer_skip_string(&buf));
+	}
+
+	free(raw);
+}
+
+static void read_register_json(struct passregister *reg, char *data)
+{
+	// parse/validate JSON data
+	cJSON *obj = type_check(cJSON_Object, cJSON_Parse(data));
+	cJSON *integers = type_check(cJSON_Array, cJSON_GetObjectItem(obj, "integers"));
+	cJSON *strings = type_check(cJSON_Array, cJSON_GetObjectItem(obj, "strings"));
+
+	reg->nr_integers = cJSON_GetArraySize(integers);
+	reg->integers = xcalloc(reg->nr_integers, sizeof(int));
+	for (size_t i = 0; i < reg->nr_integers; i++) {
+		cJSON *value = type_check(cJSON_Number, cJSON_GetArrayItem(integers, i));
+		reg->integers[i] = value->valueint;
+	}
+	reg->nr_strings = cJSON_GetArraySize(strings);
+	reg->strings = xcalloc(reg->nr_strings, sizeof(char*));
+	for (size_t i = 0; i < reg->nr_strings; i++) {
+		cJSON *value = type_check(cJSON_String, cJSON_GetArrayItem(strings, i));
+		reg->strings[i] = strdup(cJSON_GetStringValue(value));
+	}
+
+	cJSON_Delete(obj);
+}
+
 static void read_register(unsigned handle, const char *filename)
 {
 	struct passregister *reg = registers + handle;
@@ -103,28 +201,15 @@ static void read_register(unsigned handle, const char *filename)
 
 	size_t data_len;
 	char *data = file_read(reg->filename, &data_len);
-	if (data) {
-		// parse/validate JSON data
-		cJSON *obj = type_check(cJSON_Object, cJSON_Parse(data));
-		cJSON *integers = type_check(cJSON_Array, cJSON_GetObjectItem(obj, "integers"));
-		cJSON *strings = type_check(cJSON_Array, cJSON_GetObjectItem(obj, "strings"));
-
-		reg->nr_integers = cJSON_GetArraySize(integers);
-		reg->integers = xcalloc(reg->nr_integers, sizeof(int));
-		for (size_t i = 0; i < reg->nr_integers; i++) {
-			cJSON *value = type_check(cJSON_Number, cJSON_GetArrayItem(integers, i));
-			reg->integers[i] = value->valueint;
-		}
-		reg->nr_strings = cJSON_GetArraySize(strings);
-		reg->strings = xcalloc(reg->nr_strings, sizeof(char*));
-		for (size_t i = 0; i < reg->nr_strings; i++) {
-			cJSON *value = type_check(cJSON_String, cJSON_GetArrayItem(strings, i));
-			reg->strings[i] = strdup(cJSON_GetStringValue(value));
-		}
-
-		cJSON_Delete(obj);
-		free(data);
+	if (!data)
+		return;
+	if (!memcmp(data, "PSR", 4)) {
+		read_register_psr(reg, (uint8_t *)data, data_len);
+	} else {
+		// JSON format created by old versions of xsystem4
+		read_register_json(reg, data);
 	}
+	free(data);
 }
 
 static bool PassRegister_SetFileName(int handle, struct string *filename)


### PR DESCRIPTION
The old JSON format can still be loaded for backwards compatibility.