### PR TITLE
VM changes for Mamanyonyo

### DIFF
--- a/src/ffi.c
+++ b/src/ffi.c
@@ -279,6 +279,11 @@ void hll_call(int libno, int fno)
 		case AIN_REF_FUNC_TYPE:
 		case AIN_REF_ARRAY_TYPE:
 			break;
+		case AIN_ARRAY_TYPE:
+			// Sys41VM doesn't make a copy when passing an array by value.
+			if (ain->version <= 1)
+				break;
+			// fallthrough
 		default:
 			variable_fini(stack[stack_ptr+j], f->arguments[i].type.data);
 			break;

--- a/src/vm.c
+++ b/src/vm.c
@@ -1435,6 +1435,7 @@ static enum opcode execute_instruction(enum opcode opcode)
 		stack_pop();
 		break;
 	}
+	case S_PLUSA:
 	case S_PLUSA2: {
 		int a = stack_peek(1).i;
 		int b = stack_peek(0).i;

--- a/src/vm.c
+++ b/src/vm.c
@@ -347,6 +347,9 @@ static int _function_call(int fno, int return_address)
 	// initialize local variables
 	for (int i = f->nr_args; i < f->nr_vars; i++) {
 		heap[slot].page->values[i] = variable_initval(f->vars[i].type.data);
+		if (ain->version <= 1 && f->vars[i].type.data == AIN_STRUCT) {
+			create_struct(f->vars[i].type.struc, &heap[slot].page->values[i]);
+		}
 	}
 	// jump to function start
 	instr_ptr = ain->functions[fno].address;

--- a/src/vm.c
+++ b/src/vm.c
@@ -1620,7 +1620,8 @@ static enum opcode execute_instruction(enum opcode opcode)
 		break;
 	}
 	case SR_ASSIGN: {
-		stack_pop(); // struct type
+		if (ain->version > 1)
+			stack_pop(); // struct type
 		int rval = stack_pop().i;
 		int lval = stack_pop().i;
 		heap_struct_assign(lval, rval);


### PR DESCRIPTION
Mamanyonyo is the second oldest System 4 game which uses ain v1 and Sys41VM.

This PR contains VM (i.e. non-HLL) changes required to run Mamanyonyo.
