### PR TITLE
Add a parameter to gfx_draw_glyph() for controlling blending behavior

### DIFF
--- a/include/gfx/font.h
+++ b/include/gfx/font.h
@@ -132,7 +132,7 @@ int gfx_get_font_space(void);
 SDL_Color gfx_get_font_color(void);
 void gfx_set_font_name(const char *name);
 
-int gfx_render_text(Texture *dst, float x, int y, char *msg, struct text_style *ts);
+int gfx_render_text(Texture *dst, float x, int y, char *msg, struct text_style *ts, bool blend);
 void gfx_draw_text_to_amap(Texture *dst, int x, int y, char *text);
 void gfx_draw_text_to_pmap(Texture *dst, int x, int y, char *text);
 float gfx_size_char(struct text_style *ts, const char *ch);

--- a/include/gfx/gfx.h
+++ b/include/gfx/gfx.h
@@ -170,7 +170,7 @@ void gfx_copy_stretch_with_alpha_map(Texture *dst, int dx, int dy, int dw, int d
 void gfx_copy_grayscale(Texture *dst, int dx, int dy, Texture *src, int sx, int sy, int w, int h);
 void gfx_draw_line(Texture *dst, int x0, int y0, int x1, int y1, int r, int g, int b);
 void gfx_draw_line_to_amap(Texture *dst, int x0, int y0, int x1, int y1, int a);
-void gfx_draw_glyph(Texture *dst, float dx, int dy, Texture *glyph, SDL_Color color, float scale_x, float bold_width);
+void gfx_draw_glyph(Texture *dst, float dx, int dy, Texture *glyph, SDL_Color color, float scale_x, float bold_width, bool blend);
 void gfx_draw_glyph_to_pmap(Texture *dst, float dx, int dy, Texture *glyph, Rectangle glyph_pos, SDL_Color color, float scale_x);
 void gfx_draw_glyph_to_amap(Texture *dst, float dx, int dy, Texture *glyph, Rectangle glyph_pos, float scale_x);
 

--- a/shaders/blend_rmap_color.f.glsl
+++ b/shaders/blend_rmap_color.f.glsl
@@ -15,12 +15,14 @@
  */
 
 uniform sampler2D tex;
-uniform vec4 color;
+uniform vec4 color;  // .a is the discard threshold
 
 in vec2 tex_coord;
 out vec4 frag_color;
 
 void main() {
-        vec4 texel = texture(tex, tex_coord);
-        frag_color = vec4(color.rgb, texel.r * color.a);
+	vec4 texel = texture(tex, tex_coord);
+	if (texel.r < color.a)
+		discard;
+	frag_color = vec4(color.rgb, texel.r);
 }

--- a/shaders/dilate.f.glsl
+++ b/shaders/dilate.f.glsl
@@ -16,7 +16,7 @@
 
 uniform sampler2D tex;
 uniform float threshold;
-uniform vec4 color;
+uniform vec4 color;  // .a is the discard threshold
 
 in vec2 tex_coord;
 out vec4 frag_color;
@@ -43,5 +43,7 @@ void main() {
 		}
 	}
 
+	if (a_out < color.a)
+		discard;
 	frag_color = vec4(color.rgb, min(a_out, 1.0));
 }

--- a/src/3d/renderer.c
+++ b/src/3d/renderer.c
@@ -824,6 +824,7 @@ void RE_render(struct sact_sprite *sp)
 	if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
 		ERROR("Incomplete framebuffer");
 
+	glClearColor(0.f, 0.f, 0.f, 1.f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	// Draw background CGs.

--- a/src/dungeon/dungeon.c
+++ b/src/dungeon/dungeon.c
@@ -271,6 +271,7 @@ static void dungeon_render(struct sact_sprite *sp)
 	if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
 		ERROR("Incomplete framebuffer");
 
+	glClearColor(0.f, 0.f, 0.f, 1.f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_CULL_FACE);

--- a/src/hll/CharSpriteManager.c
+++ b/src/hll/CharSpriteManager.c
@@ -181,7 +181,7 @@ static void charsprite_render(struct charsprite *cs)
 
 	sprite_init_color(&cs->sp, w, h, 0, 0, 0, 0);
 	sprite_get_texture(&cs->sp); // XXX: force initialization of texture
-	gfx_render_text(&cs->sp.texture, 0.0f, 0, ch, &cs->ts);
+	gfx_render_text(&cs->sp.texture, 0.0f, 0, ch, &cs->ts, false);
 	sprite_dirty(&cs->sp);
 }
 

--- a/src/hll/Gpx2Plus.c
+++ b/src/hll/Gpx2Plus.c
@@ -529,7 +529,7 @@ static void Gpx2Plus_MsgDraw(int surface, int x, int y)
 				skiplen = strlen(s);
 			}
 			pos.y += line_height - ts.size;  // bottom align
-			pos.x += gfx_render_text(dst, pos.x, pos.y, s, &ts);
+			pos.x += gfx_render_text(dst, pos.x, pos.y, s, &ts, true);
 			pos.y -= line_height - ts.size;
 			if (lb)
 				*lb = '<';

--- a/src/hll/SengokuRanceFont.c
+++ b/src/hll/SengokuRanceFont.c
@@ -244,8 +244,7 @@ static void SengokuRanceFont_SP_TextClear(int sp_no)
 {
 	struct sact_sprite *sp = sact_try_get_sprite(sp_no);
 	if (!sp) return;
-	gfx_fill_with_alpha(sprite_get_texture(sp), 0, 0, sp->rect.w, sp->rect.h, 0, 0, 0, 0);
-	sprite_dirty(sp);
+	sprite_text_clear(sp);
 }
 
 static void SengokuRanceFont_SP_TextCopy(int dno, int sno)
@@ -256,12 +255,7 @@ static void SengokuRanceFont_SP_TextCopy(int dno, int sno)
 		return;
 
 	// copy texture
-	gfx_delete_texture(&dsp->texture);
-	if (ssp->texture.handle) {
-		struct texture *dtex = sprite_get_texture(dsp);
-		struct texture *stex = sprite_get_texture(ssp);
-		gfx_copy_with_alpha_map(dtex, 0, 0, stex, 0, 0, dsp->rect.w, dsp->rect.h);
-	}
+	sprite_text_copy(dsp, ssp);
 
 	// copy properties
 	struct sr_text_properties *d_prop = get_sp_properties(dno);
@@ -333,7 +327,9 @@ static float sp_text_draw(struct sact_sprite *sp, struct sr_text_properties *tp,
 		tp->ts.size = 8;
 	}
 
-	struct texture *tex = sprite_get_texture(sp);
+	if (!sp->text.texture.handle) {
+		gfx_init_texture_rgba(&sp->text.texture, sp->rect.w, sp->rect.h, COLOR(0, 0, 0, 0));
+	}
 
 	// save last char code
 	int last_char = -1;
@@ -343,7 +339,7 @@ static float sp_text_draw(struct sact_sprite *sp, struct sr_text_properties *tp,
 	tp->last_char = last_char;
 
 	sprite_dirty(sp);
-	return gfx_render_text(tex, x ,y, text->text, &tp->ts, false);
+	return gfx_render_text(&sp->text.texture, x, y, text->text, &tp->ts, false);
 }
 
 static void SengokuRanceFont_SP_TextDraw(int sp_no, struct string *text)

--- a/src/hll/SengokuRanceFont.c
+++ b/src/hll/SengokuRanceFont.c
@@ -343,7 +343,7 @@ static float sp_text_draw(struct sact_sprite *sp, struct sr_text_properties *tp,
 	tp->last_char = last_char;
 
 	sprite_dirty(sp);
-	return gfx_render_text(tex, x ,y, text->text, &tp->ts);
+	return gfx_render_text(tex, x ,y, text->text, &tp->ts, false);
 }
 
 static void SengokuRanceFont_SP_TextDraw(int sp_no, struct string *text)

--- a/src/hll/StoatSpriteEngine.c
+++ b/src/hll/StoatSpriteEngine.c
@@ -120,7 +120,7 @@ bool StoatSpriteEngine_SP_SetTextSprite(int sp_no, struct string *text)
 		w /= 2;
 	struct sact_sprite *sp = sact_create_sprite(sp_no, w, h, 0, 0, 0, 0);
 	sprite_get_texture(sp); // XXX: force initialization of texture
-	gfx_render_text(&sp->texture, 0.0f, 0, s, &text_sprite_ts);
+	gfx_render_text(&sp->texture, 0.0f, 0, s, &text_sprite_ts, false);
 	sprite_dirty(sp);
 	return true;
 }
@@ -457,7 +457,7 @@ static bool StoatSpriteEngine_MultiSprite_SetText(int type, int n, struct string
 	int h = ms->ts.size;
 	sprite_init_color(&ms->sp, w, h, 0, 0, 0, 0);
 	sprite_get_texture(&ms->sp); // XXX: force initialization of texture
-	gfx_render_text(&ms->sp.texture, 0.0f, 0, text->text, &ms->ts);
+	gfx_render_text(&ms->sp.texture, 0.0f, 0, text->text, &ms->ts, false);
 	sprite_dirty(&ms->sp);
 
 	ms->cg = 1;

--- a/src/hll/vmDrawMsg.c
+++ b/src/hll/vmDrawMsg.c
@@ -161,17 +161,17 @@ static int vmDrawMsg_Draw(int handle)
 				struct vm_surface *sf = vm_surface_get(dm->surfaces[SURFACE_DROP_SHADOW]);
 				int x = dm->pos.x + dm->style.drop_shadow;
 				int y = dm->pos.y + dm->style.drop_shadow;
-				gfx_render_text(&sf->texture, x, y, s, &ts);
+				gfx_render_text(&sf->texture, x, y, s, &ts, false);
 			}
 			if (dm->style.bold) {
 				struct text_style ts = dm->style.ts;
 				ts.bold_width = dm->style.bold;
 				ts.color = dm->style.bold_color;
 				struct vm_surface *sf = vm_surface_get(dm->surfaces[SURFACE_BOLD]);
-				gfx_render_text(&sf->texture, dm->pos.x, dm->pos.y, s, &ts);
+				gfx_render_text(&sf->texture, dm->pos.x, dm->pos.y, s, &ts, false);
 			}
 			struct vm_surface *sf = vm_surface_get(dm->surfaces[SURFACE_TEXT]);
-			dm->pos.x += gfx_render_text(&sf->texture, dm->pos.x, dm->pos.y, s, &dm->style.ts);
+			dm->pos.x += gfx_render_text(&sf->texture, dm->pos.x, dm->pos.y, s, &dm->style.ts, false);
 			if (lb)
 				*lb = '<';
 		} else if (sscanf(s, "<C%d,%d,%d>%n", &a1, &a2, &a3, &skiplen) == 3) {

--- a/src/parts/construction.c
+++ b/src/parts/construction.c
@@ -352,7 +352,7 @@ static void build_copy_cut_cg(struct parts_construction_process *cproc, struct p
 
 static void build_draw_text(struct parts_construction_process *cproc, struct parts_cp_text *op)
 {
-	gfx_render_text(&cproc->common.texture, op->x, op->y, op->text->text, &op->style);
+	gfx_render_text(&cproc->common.texture, op->x, op->y, op->text->text, &op->style, true);
 }
 
 static void build_copy_text(struct parts_construction_process *cproc, struct parts_cp_text *op)
@@ -361,7 +361,7 @@ static void build_copy_text(struct parts_construction_process *cproc, struct par
 	int h = ceilf(op->style.size + op->style.edge_up + op->style.edge_down);
 	gfx_fill_with_alpha(&cproc->common.texture, op->x, op->y, w, h,
 			op->style.edge_color.r, op->style.edge_color.g, op->style.edge_color.b, 0);
-	gfx_render_text(&cproc->common.texture, op->x, op->y, op->text->text, &op->style);
+	gfx_render_text(&cproc->common.texture, op->x, op->y, op->text->text, &op->style, false);
 }
 
 bool parts_build_construction_process(struct parts *parts,

--- a/src/parts/text.c
+++ b/src/parts/text.c
@@ -83,7 +83,7 @@ static const char *parts_text_append_char(struct parts_text *t, const char *str)
 	int width = text_style_width(&t->ts, ch->ch);
 	int height = text_style_height(&t->ts);
 	gfx_init_texture_rgba(&ch->t, width, height, (SDL_Color){0,0,0,0});
-	ch->advance = gfx_render_text(&ch->t, 0, 0, ch->ch, &t->ts);
+	ch->advance = gfx_render_text(&ch->t, 0, 0, ch->ch, &t->ts, false);
 
 	line->width += width;
 	line->height = max(line->height, height);

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -372,17 +372,11 @@ void sprite_set_text_pos(struct sact_sprite *sp, int x, int y)
 void sprite_text_draw(struct sact_sprite *sp, struct string *text, struct text_style *ts)
 {
 	if (!sp->text.texture.handle) {
-		SDL_Color c;
-		if (text_style_has_edge(ts))
-			c = ts->edge_color;
-		else
-			c = ts->color;
-		c.a = 0;
-		gfx_init_texture_rgba(&sp->text.texture, sp->rect.w, sp->rect.h, c);
+		gfx_init_texture_rgba(&sp->text.texture, sp->rect.w, sp->rect.h, COLOR(0, 0, 0, 0));
 	}
 
 	ts->font_spacing = sp->text.char_space;
-	sp->text.pos.x += gfx_render_text(&sp->text.texture, sp->text.pos.x, sp->text.pos.y, text->text, ts);
+	sp->text.pos.x += gfx_render_text(&sp->text.texture, sp->text.pos.x, sp->text.pos.y, text->text, ts, false);
 	if (sp->text.current_line_height < ts->size)
 		sp->text.current_line_height = ts->size;
 	sprite_dirty(sp);


### PR DESCRIPTION
This piece of code was added in a25f066 to eliminate text halo in the MangaGamer version of Sengoku Rance.

Text rendering is often a performance bottleneck. By omitting it for games other than Sengoku Rance, `gfx_draw_glyph()` becomes almost twice as fast.