### PR TITLE
Fix signature mismatch in HLL_EXPORT functions

### DIFF
--- a/include/parts.h
+++ b/include/parts.h
@@ -165,15 +165,15 @@ void PE_AddMotionAlpha(int parts_no, int begin_a, int end_a, int begin_t, int en
 void PE_AddMotionAlpha_curve(int parts_no, int begin_a, int end_a, int begin_t, int end_t,
 		struct string *curve_name);
 void PE_AddMotionCG_by_index(int parts_no, int begin_cg_no, int nr_cg, int begin_t, int end_t);
-void PE_AddMotionHGaugeRate(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t);
-void PE_AddMotionHGaugeRate_curve(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t,
+void PE_AddMotionHGaugeRate(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t);
+void PE_AddMotionHGaugeRate_curve(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t,
 			    struct string *curve_name);
-void PE_AddMotionVGaugeRate(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t);
-void PE_AddMotionVGaugeRate_curve(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t,
+void PE_AddMotionVGaugeRate(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t);
+void PE_AddMotionVGaugeRate_curve(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t,
 			    struct string *curve_name);
 void PE_AddMotionNumeralNumber(int parts_no, int begin_n, int end_n, int begin_t, int end_t);
 void PE_AddMotionNumeralNumber_curve(int parts_no, int begin_n, int end_n, int begin_t,

--- a/src/hll/DrawGraph.c
+++ b/src/hll/DrawGraph.c
@@ -263,9 +263,34 @@ static void DrawGraph_DrawTextToAMap(int dst, int x, int y, struct string *s)
 	gfx_draw_text_to_amap(DTEX(dst), x, y, s->text);
 }
 
+static void DrawGraph_SetFontSize(int size)
+{
+	gfx_set_font_size(size);
+}
+
 static void DrawGraph_SetFontName(struct string *text)
 {
 	gfx_set_font_name(text->text);
+}
+
+static void DrawGraph_SetFontWeight(int weight)
+{
+	gfx_set_font_weight(weight);
+}
+
+static void DrawGraph_SetFontUnderline(int flag)
+{
+	gfx_set_font_underline(flag);
+}
+
+static void DrawGraph_SetFontStrikeOut(int flag)
+{
+	gfx_set_font_strikeout(flag);
+}
+
+static void DrawGraph_SetFontSpace(int space)
+{
+	gfx_set_font_space(space);
 }
 
 HLL_WARN_UNIMPLEMENTED(string_ref(&EMPTY_STRING), struct string*, DrawGraph, GetFontName, void);
@@ -467,12 +492,12 @@ HLL_LIBRARY(DrawGraph,
 	    HLL_EXPORT(CopyReduceAMap, DrawGraph_CopyStretchAMap),
 	    HLL_EXPORT(DrawTextToPMap, DrawGraph_DrawTextToPMap),
 	    HLL_EXPORT(DrawTextToAMap, DrawGraph_DrawTextToAMap),
-	    HLL_EXPORT(SetFontSize, gfx_set_font_size),
+	    HLL_EXPORT(SetFontSize, DrawGraph_SetFontSize),
 	    HLL_EXPORT(SetFontName, DrawGraph_SetFontName),
-	    HLL_EXPORT(SetFontWeight, gfx_set_font_weight),
-	    HLL_EXPORT(SetFontUnderline, gfx_set_font_underline),
-	    HLL_EXPORT(SetFontStrikeOut, gfx_set_font_strikeout),
-	    HLL_EXPORT(SetFontSpace, gfx_set_font_space),
+	    HLL_EXPORT(SetFontWeight, DrawGraph_SetFontWeight),
+	    HLL_EXPORT(SetFontUnderline, DrawGraph_SetFontUnderline),
+	    HLL_EXPORT(SetFontStrikeOut, DrawGraph_SetFontStrikeOut),
+	    HLL_EXPORT(SetFontSpace, DrawGraph_SetFontSpace),
 	    HLL_EXPORT(SetFontColor, DrawGraph_SetFontColor),
 	    HLL_EXPORT(GetFontSize, gfx_get_font_size),
 	    HLL_EXPORT(GetFontName, DrawGraph_GetFontName),

--- a/src/hll/DrawMovie.c
+++ b/src/hll/DrawMovie.c
@@ -77,10 +77,17 @@ static int DrawMovie_GetCount(void)
 	return movie_get_position(mc);
 }
 
+static void DrawMovie2_SetInnerVolume(int inner_volume)
+{
+	DrawMovie_SetVolume(inner_volume);
+}
+
 static void DrawMovie2_UpdateVolume(void)
 {
 	// Do nothing, as SetInnerVolume immediately takes effect.
 }
+
+HLL_QUIET_UNIMPLEMENTED(, void, DrawMovie3, UpdateVolume, bool IsMuteByInactiveWindow);
 
 HLL_LIBRARY(DrawMovie,
 	    HLL_EXPORT(Release, DrawMovie_Release),
@@ -98,7 +105,7 @@ HLL_LIBRARY(DrawMovie2,
 	    HLL_EXPORT(Run, DrawMovie_Run),
 	    HLL_EXPORT(Draw, DrawMovie_Draw),
 	    HLL_EXPORT(SetVolume, DrawMovie_SetVolume),
-	    HLL_EXPORT(SetInnerVolume, DrawMovie_SetVolume),
+	    HLL_EXPORT(SetInnerVolume, DrawMovie2_SetInnerVolume),
 	    HLL_EXPORT(UpdateVolume, DrawMovie2_UpdateVolume),
 	    HLL_EXPORT(IsEnd, DrawMovie_IsEnd),
 	    HLL_EXPORT(GetCount, DrawMovie_GetCount)
@@ -109,8 +116,8 @@ HLL_LIBRARY(DrawMovie3,
 	    HLL_EXPORT(Load, DrawMovie_Load),
 	    HLL_EXPORT(Run, DrawMovie_Run),
 	    HLL_EXPORT(Draw, DrawMovie_Draw),
-	    HLL_EXPORT(SetInnerVolume, DrawMovie_SetVolume),
-	    HLL_EXPORT(UpdateVolume, DrawMovie2_UpdateVolume),
+	    HLL_EXPORT(SetInnerVolume, DrawMovie2_SetInnerVolume),
+	    HLL_EXPORT(UpdateVolume, DrawMovie3_UpdateVolume),
 	    HLL_EXPORT(IsEnd, DrawMovie_IsEnd),
 	    HLL_EXPORT(GetCount, DrawMovie_GetCount)
 	);

--- a/src/hll/GUIEngine.c
+++ b/src/hll/GUIEngine.c
@@ -47,8 +47,17 @@ bool GUIEngine_Load(struct page **buffer)
 }
 
 //static void GUIEngine_Release(int PartsNumber);
-//static void GUIEngine_ReleaseAll(ref array<int> EraseNumberList);
-//static void GUIEngine_ReleaseAllWithoutSystem(ref array<int> EraseNumberList);
+
+static void GUIEngine_ReleaseAll(possibly_unused struct page **erase_number_list)
+{
+	PE_ReleaseAllParts();
+}
+
+static void GUIEngine_ReleaseAllWithoutSystem(possibly_unused struct page **erase_number_list)
+{
+	PE_ReleaseAllPartsWithoutSystem();
+}
+
 //static void GUIEngine_SetDelegateIndex(int PartsNumber, int DelegateIndex);
 //static int GUIEngine_GetFreeNumber(void)
 //static bool GUIEngine_IsExist(int PartsNumber);
@@ -447,7 +456,12 @@ HLL_QUIET_UNIMPLEMENTED(0, int, GUIEngine, GetMessageType);
 //static void GUIEngine_Parts_SetOnCursorShowLinkPartsNumber(int PartsNumber, int LinkPartsNumber);
 //static void GUIEngine_Parts_SetPartsMessageWindowShowLink(int PartsNumber, bool MessageWindowShowLink);
 //static void GUIEngine_Parts_SetSoundNumber(int PartsNumber, int SoundNumber, int State);
-//static void GUIEngine_Parts_SetClickMissSoundNumber(int SoundNumber);
+
+static void GUIEngine_Parts_SetClickMissSoundNumber(int sound_number)
+{
+	PE_SetClickMissSoundNumber(sound_number);
+}
+
 //static void GUIEngine_Parts_SetPartsMagX(int PartsNumber, float MagX);
 //static void GUIEngine_Parts_SetPartsMagY(int PartsNumber, float MagY);
 //static void GUIEngine_Parts_SetPartsRotateX(int PartsNumber, float RotateX);
@@ -520,8 +534,8 @@ HLL_LIBRARY(GUIEngine,
 	    HLL_EXPORT(_ModuleFini, GUIEngine_ModuleFini),
 	    HLL_EXPORT(Init, PE_Init),
 	    HLL_EXPORT(Release, PE_ReleaseParts),
-	    HLL_EXPORT(ReleaseAll, PE_ReleaseAllParts),
-	    HLL_EXPORT(ReleaseAllWithoutSystem, PE_ReleaseAllPartsWithoutSystem),
+	    HLL_EXPORT(ReleaseAll, GUIEngine_ReleaseAll),
+	    HLL_EXPORT(ReleaseAllWithoutSystem, GUIEngine_ReleaseAllWithoutSystem),
 	    HLL_EXPORT(SetDelegateIndex, PE_SetDelegateIndex),
 	    HLL_EXPORT(GetFreeNumber, PE_GetFreeNumber),
 	    HLL_EXPORT(IsExist, PE_IsExist),
@@ -917,7 +931,7 @@ HLL_LIBRARY(GUIEngine,
 	    HLL_EXPORT(Parts_SetOnCursorShowLinkPartsNumber, PE_SetOnCursorShowLinkPartsNumber),
 	    HLL_EXPORT(Parts_SetPartsMessageWindowShowLink, PE_SetPartsMessageWindowShowLink),
 	    HLL_TODO_EXPORT(Parts_SetSoundNumber, GUIEngine_Parts_SetSoundNumber),
-	    HLL_EXPORT(Parts_SetClickMissSoundNumber, PE_SetClickMissSoundNumber),
+	    HLL_EXPORT(Parts_SetClickMissSoundNumber, GUIEngine_Parts_SetClickMissSoundNumber),
 	    HLL_EXPORT(Parts_SetPartsMagX, PE_SetPartsMagX),
 	    HLL_EXPORT(Parts_SetPartsMagY, PE_SetPartsMagY),
 	    HLL_EXPORT(Parts_SetPartsRotateX, PE_SetPartsRotateX),

--- a/src/hll/GoatGUIEngine.c
+++ b/src/hll/GoatGUIEngine.c
@@ -34,6 +34,16 @@ static inline float rad2deg(float rad)
 
 static void GoatGUIEngine_PreLink(void);
 
+static void GoatGUIEngine_AddMotionHGaugeRate(int parts_no, int begin_numerator, int begin_denominator, int end_numerator, int end_denominator, int begin_t, int end_t)
+{
+	PE_AddMotionHGaugeRate(parts_no, (float)begin_numerator, (float)begin_denominator, (float)end_numerator, (float)end_denominator, begin_t, end_t);
+}
+
+static void GoatGUIEngine_AddMotionVGaugeRate(int parts_no, int begin_numerator, int begin_denominator, int end_numerator, int end_denominator, int begin_t, int end_t)
+{
+	PE_AddMotionVGaugeRate(parts_no, (float)begin_numerator, (float)begin_denominator, (float)end_numerator, (float)end_denominator, begin_t, end_t);
+}
+
 static void GoatGUIEngine_AddMotionRotateX(int parts_no, float begin, float end,
 		int begin_t, int end_t)
 {
@@ -140,8 +150,8 @@ HLL_LIBRARY(GoatGUIEngine,
 	    HLL_EXPORT(AddMotionPos, PE_AddMotionPos),
 	    HLL_EXPORT(AddMotionAlpha, PE_AddMotionAlpha),
 	    HLL_TODO_EXPORT(AddMotionCG, PE_AddMotionCG),
-	    HLL_EXPORT(AddMotionHGaugeRate, PE_AddMotionHGaugeRate),
-	    HLL_EXPORT(AddMotionVGaugeRate, PE_AddMotionVGaugeRate),
+	    HLL_EXPORT(AddMotionHGaugeRate, GoatGUIEngine_AddMotionHGaugeRate),
+	    HLL_EXPORT(AddMotionVGaugeRate, GoatGUIEngine_AddMotionVGaugeRate),
 	    HLL_EXPORT(AddMotionNumeralNumber, PE_AddMotionNumeralNumber),
 	    HLL_EXPORT(AddMotionMagX, PE_AddMotionMagX),
 	    HLL_EXPORT(AddMotionMagY, PE_AddMotionMagY),

--- a/src/hll/Gpx2Plus.c
+++ b/src/hll/Gpx2Plus.c
@@ -428,6 +428,11 @@ static void Gpx2Plus_DrawTextToAMap(int surface, int x, int y, struct string *te
 	gfx_draw_text_to_amap(dst, x, y, text->text);
 }
 
+static void Gpx2Plus_SetFontSize(int size)
+{
+	gfx_set_font_size(size);
+}
+
 static void Gpx2Plus_SetFontName(struct string *name)
 {
 	char *u = sjis2utf(name->text, name->size);
@@ -438,6 +443,26 @@ static void Gpx2Plus_SetFontName(struct string *name)
 	else
 		WARNING("Unknown font name '%s'", display_utf0(u));
 	free(u);
+}
+
+static void Gpx2Plus_SetFontWeight(int weight)
+{
+	gfx_set_font_weight(weight);
+}
+
+static void Gpx2Plus_SetFontUnderline(int flag)
+{
+	gfx_set_font_underline(flag);
+}
+
+static void Gpx2Plus_SetFontStrikeOut(int flag)
+{
+	gfx_set_font_strikeout(flag);
+}
+
+static void Gpx2Plus_SetFontSpace(int space)
+{
+	gfx_set_font_space(space);
 }
 
 static void Gpx2Plus_SetFontColor(int r, int g, int b)
@@ -788,12 +813,12 @@ HLL_LIBRARY(Gpx2Plus,
 			HLL_EXPORT(Update, Gpx2Plus_Update),
 			HLL_EXPORT(DrawText, Gpx2Plus_DrawText),
 			HLL_EXPORT(DrawTextToAMap, Gpx2Plus_DrawTextToAMap),
-			HLL_EXPORT(SetFontSize, gfx_set_font_size),
+			HLL_EXPORT(SetFontSize, Gpx2Plus_SetFontSize),
 			HLL_EXPORT(SetFontName, Gpx2Plus_SetFontName),
-			HLL_EXPORT(SetFontWeight, gfx_set_font_weight),
-			HLL_EXPORT(SetFontUnderline, gfx_set_font_underline),
-			HLL_EXPORT(SetFontStrikeOut, gfx_set_font_strikeout),
-			HLL_EXPORT(SetFontSpace, gfx_set_font_space),
+			HLL_EXPORT(SetFontWeight, Gpx2Plus_SetFontWeight),
+			HLL_EXPORT(SetFontUnderline, Gpx2Plus_SetFontUnderline),
+			HLL_EXPORT(SetFontStrikeOut, Gpx2Plus_SetFontStrikeOut),
+			HLL_EXPORT(SetFontSpace, Gpx2Plus_SetFontSpace),
 			HLL_EXPORT(SetFontColor, Gpx2Plus_SetFontColor),
 			HLL_EXPORT(GetFontSize, gfx_get_font_size),
 			// HLL_EXPORT(GetFontName, Gpx2Plus_GetFontName),

--- a/src/hll/Timer.c
+++ b/src/hll/Timer.c
@@ -19,7 +19,7 @@
 #include "hll.h"
 #include "vm.h"
 
-HLL_WARN_UNIMPLEMENTED(1, int, Timer, Init, void *imainsystem);
+HLL_WARN_UNIMPLEMENTED(, void, Timer, Init, void *imainsystem);
 
 static int Timer_Get(void)
 {

--- a/src/parts/motion.c
+++ b/src/parts/motion.c
@@ -286,18 +286,18 @@ void PE_AddMotionCG_by_index(int parts_no, int begin_cg_no, int nr_cg, int begin
 	parts_add_motion(parts, motion);
 }
 
-void PE_AddMotionHGaugeRate(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t)
+void PE_AddMotionHGaugeRate(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t)
 {
 	struct parts *parts = parts_get(parts_no);
 	struct parts_motion *motion = parts_motion_alloc(PARTS_MOTION_HGAUGE_RATE, begin_t, end_t);
-	motion->begin.f = (float)begin_numerator / (float)begin_denominator;
-	motion->end.f = (float)end_numerator / (float)end_denominator;
+	motion->begin.f = begin_numerator / begin_denominator;
+	motion->end.f = end_numerator / end_denominator;
 	parts_add_motion(parts, motion);
 }
 
-void PE_AddMotionHGaugeRate_curve(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t,
+void PE_AddMotionHGaugeRate_curve(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t,
 			    struct string *curve_name)
 {
 	// TODO: use curve
@@ -305,18 +305,18 @@ void PE_AddMotionHGaugeRate_curve(int parts_no, int begin_numerator, int begin_d
 			end_numerator, end_denominator, begin_t, end_t);
 }
 
-void PE_AddMotionVGaugeRate(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t)
+void PE_AddMotionVGaugeRate(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t)
 {
 	struct parts *parts = parts_get(parts_no);
 	struct parts_motion *motion = parts_motion_alloc(PARTS_MOTION_VGAUGE_RATE, begin_t, end_t);
-	motion->begin.f = (float)begin_numerator / (float)begin_denominator;
-	motion->end.f = (float)end_numerator / (float)end_denominator;
+	motion->begin.f = begin_numerator / begin_denominator;
+	motion->end.f = end_numerator / end_denominator;
 	parts_add_motion(parts, motion);
 }
 
-void PE_AddMotionVGaugeRate_curve(int parts_no, int begin_numerator, int begin_denominator,
-			    int end_numerator, int end_denominator, int begin_t, int end_t,
+void PE_AddMotionVGaugeRate_curve(int parts_no, float begin_numerator, float begin_denominator,
+			    float end_numerator, float end_denominator, int begin_t, int end_t,
 			    struct string *curve_name)
 {
 	// TODO: use curve


### PR DESCRIPTION
Notable changes:

* The `numerator` / `denominator` parameters of `AddMotion[HV]GaugeRate` are int in GoatGUIEngine but float in GUIEngine and PartsEngine.
* `AnteaterADVEngine.ADVLogList_AddText` has second parameter (`int WindowNo`) since Oyako Rankan.

This also avoids using non-void functions where a void function is expected. It is fine in most ABIs, but raises a runtime error in wasm32.