### PR TITLE
Update rsave_read() parameters to specify read mode

### DIFF
--- a/include/debugger.h
+++ b/include/debugger.h
@@ -103,7 +103,7 @@ void dbg_scm_repl(void);
 #endif /* HAVE_SCHEME */
 #else  /* DEBUGGER ENABLED */
 #define dbg_init()
-#define dbg_repl()
+#define dbg_repl(type, msg)
 #define dbg_dap 0
 #define dbg_dap_handle_messages()
 #define dbg_dap_log(log, fmt, ap)

--- a/src/resume.c
+++ b/src/resume.c
@@ -835,7 +835,7 @@ static enum savefile_error load_rsave_image(const char *key, const char *path)
 {
 	char *full_path = savedir_path(path);
 	enum savefile_error error;
-	struct rsave *save = rsave_read(full_path, &error);
+	struct rsave *save = rsave_read(full_path, RSAVE_READ_ALL, &error);
 	free(full_path);
 	if (error != SAVEFILE_SUCCESS)
 		return error;
@@ -904,7 +904,7 @@ static struct page *load_json_image_comments(const char *key, const char *path, 
 static struct page *load_rsave_image_comments(const char *key, const char *path, enum savefile_error *error)
 {
 	char *full_path = savedir_path(path);
-	struct rsave *save = rsave_read(full_path, error);
+	struct rsave *save = rsave_read(full_path, RSAVE_READ_COMMENTS, error);
 	free(full_path);
 	if (*error != SAVEFILE_SUCCESS)
 		return NULL;
@@ -951,7 +951,7 @@ static int write_rsave_image_comments(const char *key, const char *path, struct 
 {
 	char *full_path = savedir_path(path);
 	enum savefile_error error;
-	struct rsave *save = rsave_read(full_path, &error);
+	struct rsave *save = rsave_read(full_path, RSAVE_READ_ALL, &error);
 	switch (error) {
 	case SAVEFILE_SUCCESS:
 		if (strcmp(key, save->key))


### PR DESCRIPTION
On my low-end Android tablet, this reduced the time it took for the save/load screen to appear in お嬢様をいいなりにするゲーム from 5 seconds to 1 second.