### PR TITLE
Add support for group save format v7

### DIFF
--- a/include/xsystem4.h
+++ b/include/xsystem4.h
@@ -23,6 +23,7 @@
 struct config {
 	char *game_name;
 	char *ain_filename;
+	char *vm_name;
 	char *game_dir;
 	char *save_dir;
 	char *home_dir;

--- a/src/system4.c
+++ b/src/system4.c
@@ -49,6 +49,7 @@ void apply_game_specific_hacks(struct ain *ain);
 struct config config = {
 	.game_name = NULL,
 	.ain_filename = NULL,
+	.vm_name = NULL,
 	.game_dir = NULL,
 	.save_dir = NULL,
 	.home_dir = NULL,
@@ -133,6 +134,8 @@ static bool read_config(const char *path)
 			config.game_name = strdup(ini_string(&ini[i])->text);
 		} else if (!strcmp(ini[i].name->text, "CodeName")) {
 			config.ain_filename = strdup(ini_string(&ini[i])->text);
+		} else if (!strcmp(ini[i].name->text, "MainVM")) {
+			config.vm_name = strdup(ini_string(&ini[i])->text);
 		} else if (!strcmp(ini[i].name->text, "SaveFolder")) {
 			config.save_dir = strdup(ini_string(&ini[i])->text);
 		} else if (!strcmp(ini[i].name->text, "ViewWidth")) {


### PR DESCRIPTION
V5 is used until Daiteikoku, and v7 since Rance Quest. Since both are Ain v6, the save version is determined by the presence of the `MainVM` field in AliceStart.ini.