### PR TITLE
Implement StoatSpriteEngine.SP_SetDashTextSprite

### DIFF
--- a/include/gfx/font.h
+++ b/include/gfx/font.h
@@ -160,6 +160,7 @@ float _gfx_render_text(Texture *dst, char *msg, struct text_render_metrics *tm);
 
 int gfx_render_text(Texture *dst, float x, int y, char *msg, struct text_style *ts, bool blend);
 float gfx_render_textf(Texture *dst, float x, int y, char *msg, struct text_style *ts, bool blend);
+void gfx_render_dash_text(Texture *dst, struct text_style *ts);
 void gfx_draw_text_to_amap(Texture *dst, int x, int y, char *text);
 void gfx_draw_text_to_pmap(Texture *dst, int x, int y, char *text);
 float gfx_size_char(struct text_style *ts, const char *ch);

--- a/src/hll/StoatSpriteEngine.c
+++ b/src/hll/StoatSpriteEngine.c
@@ -162,8 +162,10 @@ void StoatSpriteEngine_SP_SetTextSpriteEdgeColor(int r, int g, int b)
 
 bool StoatSpriteEngine_SP_SetDashTextSprite(int sp_no, int width, int height)
 {
-	// TODO: This function just draws a horizontal line on the sprite texture
-	NOTICE("StoatSpriteEngine.SP_SetDashTextSprite(%d, %d, %d)", sp_no, width, height);
+	struct sact_sprite *sp = sact_create_sprite(sp_no, width, height, 0, 0, 0, 0);
+	sprite_get_texture(sp); // XXX: force initialization of texture
+	gfx_render_dash_text(&sp->texture, &text_sprite_ts);
+	sprite_dirty(sp);
 	return true;
 }
 

--- a/src/text.c
+++ b/src/text.c
@@ -294,6 +294,27 @@ int gfx_render_text(Texture *dst, float x, int y, char *msg, struct text_style *
 	return lroundf(gfx_render_textf(dst, x, y, msg, ts, blend));
 }
 
+void gfx_render_dash_text(Texture *dst, struct text_style *ts)
+{
+	Texture glyph;
+	gfx_init_texture_rgba(&glyph, dst->w, dst->h, COLOR(0, 0, 0, 0));
+
+	// draw a horizontal line
+	int x = lroundf(ts->size * 0.12f);
+	int w = dst->w - x * 2;
+	int h = max(1, lroundf(ts->size * 0.06f));
+	int y = (ts->size - h) / 2;
+	gfx_fill(&glyph, x, y, w, h, 255, 255, 255);
+
+	float edge_width = text_style_edge_width(ts);
+	if (edge_width > 0.01f) {
+		gfx_draw_glyph(dst, 0, 0, &glyph, ts->edge_color, 1.f, edge_width, false);
+	}
+	gfx_draw_glyph(dst, 0, 0, &glyph, ts->color, 1.f, ts->bold_width, false);
+
+	gfx_delete_texture(&glyph);
+}
+
 struct font_metrics {
 	int size;
 	enum font_face face;


### PR DESCRIPTION
This implementation creates a temporary "glyph" texture and draws it to the sprite using `gfx_draw_glyph()`.