### PR TITLE
TapirEngine: Proper collision detection

### DIFF
--- a/include/reign.h
+++ b/include/reign.h
@@ -212,6 +212,7 @@ bool RE_instance_set_vertex_pos(struct RE_instance *instance, int index, float x
 int RE_instance_get_bone_index(struct RE_instance *instance, const char *name);
 bool RE_instance_trans_local_pos_to_world_pos_by_bone(struct RE_instance *instance, int bone, vec3 offset, vec3 out);
 float RE_instance_calc_height(struct RE_instance *instance, float x, float z);
+float RE_instance_calc_2d_detection_height(struct RE_instance *instance, float x, float z);
 bool RE_instance_calc_2d_detection(struct RE_instance *instance, float x0, float y0, float z0, float x1, float y1, float z1, float *x2, float *y2, float *z2, float radius);
 bool RE_instance_set_debug_draw_shadow_volume(struct RE_instance *instance, bool draw);
 

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ ffi = dependency('libffi', static : static_libs)
 tj = dependency('libturbojpeg', static : static_libs)
 webp = dependency('libwebp', static : static_libs)
 png = dependency('libpng', static : static_libs)
-cglm = dependency('cglm', version : '>=0.8.3', fallback : ['cglm', 'cglm_dep'])
+cglm = dependency('cglm', version : '>=0.9.2', fallback : ['cglm', 'cglm_dep'])
 sndfile = dependency('sndfile', static : static_libs)
 
 avcodec = dependency('libavcodec', version : '>=59.37.100', required: false, static : static_libs)

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -515,15 +515,25 @@ struct amt_material *amt_find_material(struct amt *amt, const char *name);
 struct collider {
 	struct collider_triangle *triangles;
 	uint32_t nr_triangles;
+	struct collider_edge *edges;  // boundary edges
+	uint32_t nr_edges;
 };
 
 struct collider_triangle {
-	vec3 vertices[3];
-	vec3 aabb[2];
+	vec2 vertices[3];  // xz coordinates
+	vec2 aabb[2];
+	vec2 slope;
+	float intercept;
 };
 
-struct collider *collider_create(struct pol *pol);
+struct collider_edge {
+	vec2 vertices[2];  // xz coordinates
+	vec2 aabb[2];
+};
+
+struct collider *collider_create(struct pol_mesh *mesh);
 void collider_free(struct collider *collider);
-bool check_collision(struct collider *collider, vec3 p0, vec3 p1, float radius, vec3 out);
+bool collider_height(struct collider *collider, vec2 xz, float *h_out);
+bool check_collision(struct collider *collider, vec2 p0, vec2 p1, float radius, vec2 out);
 
 #endif /* SYSTEM4_3D_3D_INTERNAL_H */

--- a/src/3d/model.c
+++ b/src/3d/model.c
@@ -463,6 +463,13 @@ struct model *model_load(struct archive *aar, const char *path)
 	for (uint32_t i = 0; i < pol->nr_meshes; i++) {
 		if (!pol->meshes[i])
 			continue;
+		if (!strcmp(pol->meshes[i]->name, "collision")) {
+			if (model->collider)
+				WARNING("multiple collision meshes");
+			else
+				model->collider = collider_create(pol->meshes[i]);
+			continue;
+		}
 		struct pol_material_group *mg = &pol->materials[pol->meshes[i]->material];
 		int m_off = material_offsets[pol->meshes[i]->material];
 		if (mg->nr_children == 0) {
@@ -473,10 +480,6 @@ struct model *model_load(struct archive *aar, const char *path)
 			add_mesh(model, pol->meshes[i], j, m_off + j);
 		}
 	}
-
-	// Collision detection is only required for maps.
-	if (strstr(path, "Map\\"))
-		model->collider = collider_create(pol);
 
 	pol_compute_aabb(pol, model->aabb);
 

--- a/src/3d/reign.c
+++ b/src/3d/reign.c
@@ -549,19 +549,29 @@ float RE_instance_calc_height(struct RE_instance *instance, float x, float z)
 	return cnt ? total / cnt : 0.0f;
 }
 
+float RE_instance_calc_2d_detection_height(struct RE_instance *instance, float x, float z)
+{
+	if (!instance || !instance->model->collider)
+		return false;
+	vec2 xz = { x, -z };
+	float h;
+	if (collider_height(instance->model->collider, xz, &h))
+		return h;
+	return 0.f;
+}
+
 bool RE_instance_calc_2d_detection(struct RE_instance *instance, float x0, float y0, float z0, float x1, float y1, float z1, float *x2, float *y2, float *z2, float radius)
 {
 	if (!instance || !instance->model->collider)
 		return false;
-	vec3 p0 = { x0, y0, -z0 };
-	vec3 p1 = { x1, y1, -z1 };
-	vec3 p2;
+	vec2 p0 = { x0, -z0 };
+	vec2 p1 = { x1, -z1 };
+	vec2 p2;
 	if (!check_collision(instance->model->collider, p0, p1, radius, p2))
 		return false;
 	*x2 = p2[0];
-	*y2 = p2[1];
-	*z2 = -p2[2];
-	return true;
+	*z2 = -p2[1];
+	return collider_height(instance->model->collider, p2, y2);
 }
 
 bool RE_instance_set_debug_draw_shadow_volume(struct RE_instance *inst, bool draw)

--- a/src/hll/ReignEngine.c
+++ b/src/hll/ReignEngine.c
@@ -1825,7 +1825,11 @@ static int TapirEngine_CreatePlugin(void)
 
 HLL_WARN_UNIMPLEMENTED(false, bool, TapirEngine, SetInstanceDrawParam, int plugin_number, int instance_number, int draw_param, int value);
 //bool TapirEngine_GetInstanceDrawParam(int PluginNumber, int InstanceNumber, int DrawParam, int *Value);
-HLL_WARN_UNIMPLEMENTED(0.0f, float, TapirEngine, CalcInstance2DDetectionHeight, int plugin_number, int instance_number, float x, float z);
+
+static float TapirEngine_CalcInstance2DDetectionHeight(int plugin, int instance, float x, float z)
+{
+	return RE_instance_calc_2d_detection_height(get_instance(plugin, instance), x, z);
+}
 
 static bool TapirEngine_CalcInstance2DDetection(int plugin, int instance, float x0, float y0, float z0, float x1, float y1, float z1, float *x2, float *y2, float *z2, float radius)
 {

--- a/subprojects/cglm.wrap
+++ b/subprojects/cglm.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/recp/cglm.git
-revision = v0.8.5
+revision = v0.9.2


### PR DESCRIPTION
Collision detection is based on a mesh named "collision" in the map's 3D model. The "collision" mesh specifies the area in which the character can move in the xz plane, and the y coordinate represents the height of the map at that point.

Now cglm 0.9.2 is required, for 2D AABB operations.