### PR TITLE
3d: Increase MAX_BONES to 308

### DIFF
--- a/include/reign.h
+++ b/include/reign.h
@@ -186,6 +186,7 @@ struct RE_instance {
 	mat4 local_transform;
 	mat3 normal_transform;
 	mat4 *bone_transforms;  // model->nr_bones elements
+	GLuint bone_transforms_ubo;
 	vec4 bounding_sphere;
 	struct RE_instance *shadow_volume_instance;
 	float z_from_camera;

--- a/shaders/reign.v.glsl
+++ b/shaders/reign.v.glsl
@@ -30,10 +30,12 @@ uniform mat4 view_transform;
 uniform mat4 proj_transform;
 uniform mat3 normal_transform;
 
-const int MAX_BONES = 211;  // see 3d_internal.h
+const int MAX_BONES = 308;  // see 3d_internal.h
 const int NR_WEIGHTS = 4;
 uniform bool has_bones;
-uniform mat4 bone_matrices[MAX_BONES];
+layout(std140) uniform BoneTransforms {
+	mat4 bone_matrices[MAX_BONES];
+};
 
 uniform bool use_normal_map;
 

--- a/shaders/reign_shadow.v.glsl
+++ b/shaders/reign_shadow.v.glsl
@@ -17,10 +17,12 @@
 uniform mat4 world_transform;
 uniform mat4 view_transform;
 
-const int MAX_BONES = 211;  // see 3d_internal.h
+const int MAX_BONES = 308;  // see 3d_internal.h
 const int NR_WEIGHTS = 4;
 uniform bool has_bones;
-uniform mat4 bone_matrices[MAX_BONES];
+layout(std140) uniform BoneTransforms {
+	mat4 bone_matrices[MAX_BONES];
+};
 
 in vec3 vertex_pos;
 in ivec4 vertex_bone_index;

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -26,7 +26,7 @@
 #include "reign.h"
 
 #define NR_DIR_LIGHTS 3
-#define MAX_BONES 211  // Maximum in TT3
+#define MAX_BONES 308  // Maximum in Rance Quest
 
 typedef struct vec3_range {
 	vec3 begin;
@@ -111,7 +111,6 @@ struct shadow_renderer {
 	GLint world_transform;
 	GLint view_transform;
 	GLint has_bones;
-	GLint bone_matrices;
 };
 
 struct RE_renderer {
@@ -128,7 +127,6 @@ struct RE_renderer {
 	GLint normal_transform;
 	GLint alpha_mod;
 	GLint has_bones;
-	GLint bone_matrices;
 	GLint ambient;
 	struct {
 		GLint dir;


### PR DESCRIPTION
This is the maximum number of bones in a model for Rance Quest (`pasuteru_full.POL`).

Now bone transform matrices are stored in a uniform buffer object, because its size exceeds `GL_MAX_VERTEX_UNIFORM_COMPONENTS` in iOS Safari.