### PR TITLE
TapirEngine: Outline rendering

### DIFF
--- a/include/reign.h
+++ b/include/reign.h
@@ -63,8 +63,14 @@ enum RE_draw_type {
 };
 
 enum RE_draw_options {
-	RE_DRAW_OPTION_UNKNOWN,
+	RE_DRAW_OPTION_EDGE = 0,
 	RE_DRAW_OPTION_MAX
+};
+
+enum RE_draw_edge_mode {
+	RE_DRAW_EDGE_NONE = 0,
+	RE_DRAW_EDGE_CHARACTERS_ONLY = 1,
+	RE_DRAW_EDGE_ALL = 2,
 };
 
 struct RE_options {

--- a/shaders/reign_outline.f.glsl
+++ b/shaders/reign_outline.f.glsl
@@ -1,0 +1,22 @@
+/* Copyright (C) 2024 kichikuou <KichikuouChrome@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://gnu.org/licenses/>.
+ */
+
+uniform vec3 outline_color;
+out vec4 frag_color;
+
+void main() {
+	frag_color = vec4(outline_color, 1.0);
+}

--- a/shaders/reign_outline.v.glsl
+++ b/shaders/reign_outline.v.glsl
@@ -1,0 +1,53 @@
+/* Copyright (C) 2024 kichikuou <KichikuouChrome@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://gnu.org/licenses/>.
+ */
+
+uniform mat4 local_transform;
+uniform mat4 view_transform;
+uniform mat4 proj_transform;
+uniform mat3 normal_transform;
+
+const int MAX_BONES = 308;  // see 3d_internal.h
+const int NR_WEIGHTS = 4;
+uniform bool has_bones;
+layout(std140) uniform BoneTransforms {
+	mat4 bone_matrices[MAX_BONES];
+};
+uniform float outline_thickness;
+
+in vec3 vertex_pos;
+in vec3 vertex_normal;
+in ivec4 vertex_bone_index;
+in vec4 vertex_bone_weight;
+
+void main() {
+	mat4 local_bone_transform = local_transform;
+	mat3 normal_bone_transform = normal_transform;
+	if (has_bones) {
+		mat4 bone_transform = mat4(0.f);
+		for (int i = 0; i < NR_WEIGHTS; i++) {
+			if (vertex_bone_index[i] >= 0) {
+				bone_transform += bone_matrices[vertex_bone_index[i]] * vertex_bone_weight[i];
+			}
+		}
+		local_bone_transform *= bone_transform;
+		normal_bone_transform *= mat3(bone_transform);
+	}
+
+	vec4 pos = local_bone_transform * vec4(vertex_pos, 1.0);
+	vec3 normal = normalize(normal_bone_transform * vertex_normal);
+
+	gl_Position = proj_transform * view_transform * (pos + vec4(normal, 0.0) * outline_thickness);
+}

--- a/shaders/reign_shadow.v.glsl
+++ b/shaders/reign_shadow.v.glsl
@@ -14,7 +14,7 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
-uniform mat4 world_transform;
+uniform mat4 local_transform;
 uniform mat4 view_transform;
 
 const int MAX_BONES = 308;  // see 3d_internal.h
@@ -29,7 +29,7 @@ in ivec4 vertex_bone_index;
 in vec4 vertex_bone_weight;
 
 void main() {
-	mat4 world_bone_transform = world_transform;
+	mat4 local_bone_transform = local_transform;
 	if (has_bones) {
 		mat4 bone_transform = mat4(0.f);
 		for (int i = 0; i < NR_WEIGHTS; i++) {
@@ -37,8 +37,8 @@ void main() {
 				bone_transform += bone_matrices[vertex_bone_index[i]] * vertex_bone_weight[i];
 			}
 		}
-		world_bone_transform *= bone_transform;
+		local_bone_transform *= bone_transform;
 	}
 
-	gl_Position = view_transform * world_bone_transform * vec4(vertex_pos, 1.0);
+	gl_Position = view_transform * local_bone_transform * vec4(vertex_pos, 1.0);
 }

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -57,6 +57,9 @@ struct mesh {
 	int nr_vertices;
 	int nr_indices;
 	int material;
+	vec3 outline_color;
+	float outline_thickness;
+	vec2 uv_scroll;
 };
 
 struct material {
@@ -113,10 +116,24 @@ struct shadow_renderer {
 	GLint has_bones;
 };
 
+struct outline_renderer {
+	GLuint program;
+
+	// Uniform variable locations
+	GLint local_transform;
+	GLint view_transform;
+	GLint proj_transform;
+	GLint normal_transform;
+	GLint has_bones;
+	GLint outline_color;
+	GLint outline_thickness;
+};
+
 struct RE_renderer {
 	GLuint program;
 	GLuint depth_buffer;
 	struct shadow_renderer shadow;
+	struct outline_renderer outline;
 
 	// Uniform variable locations
 	GLint view_transform;
@@ -189,7 +206,7 @@ struct archive_data *RE_get_aar_entry(struct archive *aar, const char *dir, cons
 
 // renderer.c
 
-struct RE_renderer *RE_renderer_new(void);
+struct RE_renderer *RE_renderer_new(enum RE_plugin_version version);
 void RE_renderer_free(struct RE_renderer *r);
 void RE_renderer_set_viewport_size(struct RE_renderer *r, int width, int height);
 bool RE_renderer_load_billboard_texture(struct RE_renderer *r, int cg_no);

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -407,11 +407,14 @@ struct pol_material_group {
 };
 
 enum mesh_flags {
-	MESH_NOLIGHTING   = 1 << 0,
-	MESH_NOMAKESHADOW = 1 << 1,
-	MESH_ENVMAP       = 1 << 2,
-	MESH_BOTH         = 1 << 3,
-	MESH_SPRITE       = 1 << 4,
+	MESH_NOLIGHTING          = 1 << 0,
+	MESH_NOMAKESHADOW        = 1 << 1,
+	MESH_ENVMAP              = 1 << 2,
+	MESH_BOTH                = 1 << 3,
+	MESH_SPRITE              = 1 << 4,
+	MESH_BLEND_ADDITIVE      = 1 << 5,
+	MESH_NO_EDGE             = 1 << 6,
+	MESH_NO_HEIGHT_DETECTION = 1 << 7,
 };
 
 struct pol_mesh {
@@ -428,6 +431,10 @@ struct pol_mesh {
 	vec3 *colors;
 	uint32_t nr_triangles;
 	struct pol_triangle *triangles;
+	// Parameters in .opr file.
+	Color edge_color;
+	float edge_size;
+	vec2 uv_scroll;
 };
 
 struct pol_vertex {
@@ -511,6 +518,8 @@ void mot_free(struct mot *mot);
 struct amt *amt_parse(uint8_t *data, size_t size);
 void amt_free(struct amt *amt);
 struct amt_material *amt_find_material(struct amt *amt, const char *name);
+
+void opr_load(uint8_t *data, size_t size, struct pol *pol);
 
 // collision.c
 

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -108,7 +108,7 @@ struct shadow_renderer {
 	GLuint texture;
 
 	// Uniform variable locations
-	GLint world_transform;
+	GLint local_transform;
 	GLint view_transform;
 	GLint has_bones;
 };
@@ -119,7 +119,6 @@ struct RE_renderer {
 	struct shadow_renderer shadow;
 
 	// Uniform variable locations
-	GLint world_transform;
 	GLint view_transform;
 	GLint texture;
 	GLint local_transform;

--- a/src/3d/model.c
+++ b/src/3d/model.c
@@ -440,6 +440,13 @@ struct model *model_load(struct archive *aar, const char *path)
 	struct model *model = xcalloc(1, sizeof(struct model));
 	model->path = strdup(path);
 
+	// Load .opr file, if any
+	struct archive_data *opr_file = RE_get_aar_entry(aar, path, basename, ".opr");
+	if (opr_file) {
+		opr_load(opr_file->data, opr_file->size, pol);
+		archive_free_data(opr_file);
+	}
+
 	// Bones
 	if (pol->nr_bones > 0) {
 		if (pol->nr_bones > MAX_BONES)

--- a/src/3d/model.c
+++ b/src/3d/model.c
@@ -29,6 +29,7 @@
 
 #define FP16_MIN 6.103516e-5f
 #define NR_WEIGHTS 4
+#define DEFAULT_OUTLINE_THICKNESS 0.003
 
 struct vertex_common {
 	GLfloat pos[3];
@@ -298,6 +299,11 @@ static void add_mesh(struct model *model, struct pol_mesh *m, uint32_t material_
 	struct mesh *mesh = &model->meshes[model->nr_meshes++];
 	mesh->flags = m->flags;
 	mesh->material = material;
+	mesh->outline_color[0] = m->edge_color.r / 255.f;
+	mesh->outline_color[1] = m->edge_color.g / 255.f;
+	mesh->outline_color[2] = m->edge_color.b / 255.f;
+	mesh->outline_thickness = m->edge_size ? m->edge_size : DEFAULT_OUTLINE_THICKNESS;
+	glm_vec2_copy(m->uv_scroll, mesh->uv_scroll);
 	mesh->nr_vertices = nr_vertices;
 
 	glGenVertexArrays(1, &mesh->vao);

--- a/src/3d/reign.c
+++ b/src/3d/reign.c
@@ -260,7 +260,7 @@ bool RE_plugin_bind(struct RE_plugin *plugin, int sprite)
 	struct sact_sprite *sp = sact_try_get_sprite(sprite);
 	if (!sp)
 		return false;
-	plugin->renderer = RE_renderer_new();
+	plugin->renderer = RE_renderer_new(plugin->version);
 	plugin->sprite = sprite;
 	sprite_bind_plugin(sp, &plugin->plugin);
 	struct texture *texture = sprite_get_texture(sp);

--- a/src/3d/renderer.c
+++ b/src/3d/renderer.c
@@ -99,7 +99,7 @@ static void init_shadow_renderer(struct shadow_renderer *sr)
 	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &orig_fbo);
 
 	sr->program = load_shader("shaders/reign_shadow.v.glsl", "shaders/reign_shadow.f.glsl");
-	sr->world_transform = glGetUniformLocation(sr->program, "world_transform");
+	sr->local_transform = glGetUniformLocation(sr->program, "local_transform");
 	sr->view_transform = glGetUniformLocation(sr->program, "view_transform");
 	sr->has_bones = glGetUniformLocation(sr->program, "has_bones");
 	GLuint bone_transforms = glGetUniformBlockIndex(sr->program, "BoneTransforms");
@@ -176,7 +176,6 @@ struct RE_renderer *RE_renderer_new(void)
 	struct RE_renderer *r = xcalloc(1, sizeof(struct RE_renderer));
 
 	r->program = load_shader("shaders/reign.v.glsl", "shaders/reign.f.glsl");
-	r->world_transform = glGetUniformLocation(r->program, "world_transform");
 	r->view_transform = glGetUniformLocation(r->program, "view_transform");
 	r->texture = glGetUniformLocation(r->program, "tex");
 	r->local_transform = glGetUniformLocation(r->program, "local_transform");
@@ -729,7 +728,7 @@ static void render_shadow_map(struct RE_plugin *plugin, mat4 light_space_transfo
 		} else {
 			glUniform1i(r->shadow.has_bones, GL_FALSE);
 		}
-		glUniformMatrix4fv(r->shadow.world_transform, 1, GL_FALSE, inst->local_transform[0]);
+		glUniformMatrix4fv(r->shadow.local_transform, 1, GL_FALSE, inst->local_transform[0]);
 		for (int j = 0; j < model->nr_meshes; j++) {
 			struct mesh *mesh = &model->meshes[j];
 			if (mesh->flags & MESH_NOMAKESHADOW)
@@ -975,7 +974,7 @@ struct height_detector *RE_renderer_create_height_detector(struct RE_renderer *r
 	glViewport(0, 0, SHADOW_WIDTH, SHADOW_HEIGHT);
 	glClear(GL_DEPTH_BUFFER_BIT);
 	glUseProgram(r->shadow.program);
-	glUniformMatrix4fv(r->shadow.world_transform, 1, GL_FALSE, view_matrix[0]);
+	glUniformMatrix4fv(r->shadow.local_transform, 1, GL_FALSE, view_matrix[0]);
 	glUniformMatrix4fv(r->shadow.view_transform, 1, GL_FALSE, proj_matrix[0]);
 	glUniform1i(r->shadow.has_bones, GL_FALSE);
 


### PR DESCRIPTION
This implements outline (called "edge" in the game config) rendering of 3D objects, using the "inverted hull" method.