### PR TITLE
TapirEngine: Simplify lighting

### DIFF
--- a/include/gfx/gfx.h
+++ b/include/gfx/gfx.h
@@ -76,7 +76,7 @@ void gfx_set_wait_vsync(bool wait);
 float gfx_get_frame_rate(void);
 
 void gfx_load_shader(struct shader *dst, const char *vertex_shader_path, const char *fragment_shader_path);
-GLuint gfx_load_shader_file(const char *path, GLenum type);
+GLuint gfx_load_shader_file(const char *path, GLenum type, const char *defines);
 
 // rendering
 void gfx_set_clear_color(int r, int g, int b, int a);

--- a/shaders/reign.v.glsl
+++ b/shaders/reign.v.glsl
@@ -14,16 +14,32 @@
  * along with this program; if not, see <http://gnu.org/licenses/>.
  */
 
+const float PI = 3.14159265358979323846;
+
+#if ENGINE == REIGN_ENGINE
+
 #define NR_DIR_LIGHTS 3
 #define FOG_LIGHT_SCATTERING 2
-
-const float PI = 3.14159265358979323846;
 
 struct dir_light {
 	vec3 dir;
 	vec3 diffuse;
 	vec3 globe_diffuse;
 };
+
+uniform dir_light dir_lights[NR_DIR_LIGHTS];
+uniform vec3 specular_light_dir;
+uniform int fog_type;
+uniform vec4 ls_params;  // (beta_r, beta_m, g, distance)
+uniform vec3 ls_light_dir;
+uniform vec3 ls_light_color;
+uniform vec3 ls_sun_color;
+out vec3 light_dir[NR_DIR_LIGHTS];
+out vec3 specular_dir;
+out vec3 ls_ex;
+out vec3 ls_in;
+
+#endif // ENGINE == REIGN_ENGINE
 
 uniform mat4 local_transform;
 uniform mat4 view_transform;
@@ -40,14 +56,7 @@ layout(std140) uniform BoneTransforms {
 uniform bool use_normal_map;
 
 uniform vec3 camera_pos;
-uniform dir_light dir_lights[NR_DIR_LIGHTS];
-uniform vec3 specular_light_dir;
 uniform mat4 shadow_transform;
-uniform int fog_type;
-uniform vec4 ls_params;  // (beta_r, beta_m, g, distance)
-uniform vec3 ls_light_dir;
-uniform vec3 ls_light_color;
-uniform vec3 ls_sun_color;
 
 in vec3 vertex_pos;
 in vec3 vertex_normal;
@@ -66,10 +75,6 @@ out vec4 shadow_frag_pos;
 out float dist;
 out vec3 eye;
 out vec3 normal;
-out vec3 light_dir[NR_DIR_LIGHTS];
-out vec3 specular_dir;
-out vec3 ls_ex;
-out vec3 ls_in;
 
 void main() {
 	mat4 local_bone_transform = local_transform;
@@ -109,6 +114,8 @@ void main() {
 	// otherwise.
 	frag_pos = TBN * vec3(world_pos);
 	eye = TBN * camera_pos;
+
+#if ENGINE == REIGN_ENGINE
 	light_dir[0] = TBN * dir_lights[0].dir;
 	light_dir[1] = TBN * dir_lights[1].dir;
 	light_dir[2] = TBN * dir_lights[2].dir;
@@ -132,4 +139,5 @@ void main() {
 		ls_in = (phase_r * beta_r + phase_m * beta_m) / (beta_r + beta_m) * (1.0 - f_ex) * ls_sun_color;
 		ls_ex = ls_light_color * f_ex;
 	}
+#endif
 }

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -143,7 +143,8 @@ struct RE_renderer {
 	GLint normal_transform;
 	GLint alpha_mod;
 	GLint has_bones;
-	GLint ambient;
+	GLint global_ambient;
+	GLint instance_ambient;
 	struct {
 		GLint dir;
 		GLint diffuse;

--- a/src/video.c
+++ b/src/video.c
@@ -83,16 +83,17 @@ static GLchar *read_shader_file(const char *path)
 	return source;
 }
 
-GLuint gfx_load_shader_file(const char *path, GLenum type)
+GLuint gfx_load_shader_file(const char *path, GLenum type, const char *defines)
 {
 	GLint shader_compiled;
 	GLuint shader;
-	const GLchar *source[2] = {
+	const GLchar *source[3] = {
 		glsl_preamble,
+		defines ? defines : "",
 		read_shader_file(path)
 	};
 	shader = glCreateShader(type);
-	glShaderSource(shader, 2, source, NULL);
+	glShaderSource(shader, 3, source, NULL);
 	glCompileShader(shader);
 	glGetShaderiv(shader, GL_COMPILE_STATUS, &shader_compiled);
 	if (!shader_compiled) {
@@ -102,15 +103,15 @@ GLuint gfx_load_shader_file(const char *path, GLenum type)
 		glGetShaderInfoLog(shader, len, NULL, infolog);
 		ERROR("Failed to compile shader %s: %s", path, infolog);
 	}
-	SDL_free((char*)source[1]);
+	SDL_free((char*)source[2]);
 	return shader;
 }
 
 void gfx_load_shader(struct shader *dst, const char *vertex_shader_path, const char *fragment_shader_path)
 {
 	GLuint program = glCreateProgram();
-	GLuint vertex_shader = gfx_load_shader_file(vertex_shader_path, GL_VERTEX_SHADER);
-	GLuint fragment_shader = gfx_load_shader_file(fragment_shader_path, GL_FRAGMENT_SHADER);
+	GLuint vertex_shader = gfx_load_shader_file(vertex_shader_path, GL_VERTEX_SHADER, NULL);
+	GLuint fragment_shader = gfx_load_shader_file(fragment_shader_path, GL_FRAGMENT_SHADER, NULL);
 
 	glAttachShader(program, vertex_shader);
 	glAttachShader(program, fragment_shader);


### PR DESCRIPTION
In TapirEngine, the following lighting features are not used:

- global ambient
- directional lights
- specular lights
- rim lights
- fog

(The setters / getters for these parameters are still there, but they don't affect rendering.)

This implementation disables those features in GLSL using `#ifdef`s. The C code that sets up the lighting remains almost unchanged -- `glGetUniformLocation()` will return -1 if the specified uniform variable name is not found, and `glUniform*(-1, ...)` will be no-op.