### PR TITLE
TapirEngine: Fix alpha test / alpha blend conditions

### DIFF
--- a/include/reign.h
+++ b/include/reign.h
@@ -98,7 +98,6 @@ struct RE_back_cg {
 
 struct RE_plugin {
 	struct draw_plugin plugin;
-	enum RE_plugin_version version;
 	int sprite;
 	int nr_instances;
 	struct RE_instance **instances;

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -46,11 +46,12 @@ struct model {
 	struct hash_table *mot_cache;  // name -> struct mot *
 	struct collider *collider;
 	vec3 aabb[2];  // axis-aligned bounding box
-	bool has_transparent_material;
+	bool has_transparent_mesh;
 };
 
 struct mesh {
 	uint32_t flags;
+	bool is_transparent;
 	GLuint vao;
 	GLuint attr_buffer;
 	GLuint index_buffer;
@@ -412,6 +413,7 @@ enum pol_texture_type {
 
 enum material_flags {
 	MATERIAL_SPRITE = 1 << 0,
+	MATERIAL_ALPHA  = 1 << 1,
 };
 
 struct pol_material {
@@ -435,6 +437,7 @@ enum mesh_flags {
 	MESH_BLEND_ADDITIVE      = 1 << 5,
 	MESH_NO_EDGE             = 1 << 6,
 	MESH_NO_HEIGHT_DETECTION = 1 << 7,
+	MESH_ALPHA               = 1 << 8,
 };
 
 struct pol_mesh {

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -193,6 +193,8 @@ struct billboard_texture {
 
 // reign.c
 
+extern enum RE_plugin_version re_plugin_version;
+
 void RE_instance_update_local_transform(struct RE_instance *inst);
 
 // model.c
@@ -208,7 +210,7 @@ struct archive_data *RE_get_aar_entry(struct archive *aar, const char *dir, cons
 
 // renderer.c
 
-struct RE_renderer *RE_renderer_new(enum RE_plugin_version version);
+struct RE_renderer *RE_renderer_new(void);
 void RE_renderer_free(struct RE_renderer *r);
 void RE_renderer_set_viewport_size(struct RE_renderer *r, int width, int height);
 bool RE_renderer_load_billboard_texture(struct RE_renderer *r, int cg_no);

--- a/src/3d/parser.c
+++ b/src/3d/parser.c
@@ -64,6 +64,8 @@ static uint32_t parse_material_attributes(const char *name)
 	uint32_t flags = 0;
 	if (strstr(name, "(sprite)"))
 		flags |= MATERIAL_SPRITE;
+	if (strstr(name, "(alpha)"))
+		flags |= MATERIAL_ALPHA;
 	return flags;
 }
 
@@ -179,6 +181,8 @@ static uint32_t parse_mesh_attributes(const char *name)
 		flags |= MESH_BOTH;
 	if (strstr(name, "(sprite)"))
 		flags |= MESH_SPRITE;
+	if (strstr(name, "(alpha)"))
+		flags |= MESH_ALPHA;
 	return flags;
 }
 

--- a/src/3d/reign.c
+++ b/src/3d/reign.c
@@ -34,6 +34,8 @@
 #include "vm.h"
 #include "xsystem4.h"
 
+enum RE_plugin_version re_plugin_version;
+
 static struct RE_instance *create_instance(struct RE_plugin *plugin)
 {
 	struct RE_instance *instance = xcalloc(1, sizeof(struct RE_instance));
@@ -207,6 +209,8 @@ static void update_bones(struct RE_instance *inst)
 
 struct RE_plugin *RE_plugin_new(enum RE_plugin_version version)
 {
+	re_plugin_version = version;
+
 	char *aar_path = gamedir_path("Data/ReignData.red");
 	int error = ARCHIVE_SUCCESS;
 	struct archive *aar = (struct archive *)aar_open(aar_path, MMAP_IF_64BIT, &error);
@@ -220,7 +224,6 @@ struct RE_plugin *RE_plugin_new(enum RE_plugin_version version)
 		return NULL;
 
 	struct RE_plugin *plugin = xcalloc(1, sizeof(struct RE_plugin));
-	plugin->version = version;
 	plugin->plugin.name = "ReignEngine";
 	plugin->plugin.update = RE_render;
 	plugin->plugin.to_json = RE_to_json;
@@ -262,7 +265,7 @@ bool RE_plugin_bind(struct RE_plugin *plugin, int sprite)
 	struct sact_sprite *sp = sact_try_get_sprite(sprite);
 	if (!sp)
 		return false;
-	plugin->renderer = RE_renderer_new(plugin->version);
+	plugin->renderer = RE_renderer_new();
 	plugin->sprite = sprite;
 	sprite_bind_plugin(sp, &plugin->plugin);
 	struct texture *texture = sprite_get_texture(sp);

--- a/src/3d/renderer.c
+++ b/src/3d/renderer.c
@@ -338,7 +338,7 @@ static void render_model(struct RE_instance *inst, struct RE_renderer *r, enum d
 	if (!inst->model)
 		return;
 	bool all_transparent = inst->alpha < 1.0f;
-	bool all_opaque = !model->has_transparent_material && inst->alpha >= 1.0f;
+	bool all_opaque = !model->has_transparent_mesh && inst->alpha >= 1.0f;
 	if ((phase == DRAW_OPAQUE && all_transparent) || (phase == DRAW_TRANSPARENT && all_opaque))
 		return;
 
@@ -362,7 +362,7 @@ static void render_model(struct RE_instance *inst, struct RE_renderer *r, enum d
 	for (int i = 0; i < model->nr_meshes; i++) {
 		struct mesh *mesh = &model->meshes[i];
 		struct material *material = &model->materials[mesh->material];
-		bool is_transparent = (material->is_transparent && !(mesh->flags & MESH_SPRITE)) || inst->alpha < 1.0f;
+		bool is_transparent = mesh->is_transparent || inst->alpha < 1.0f;
 		if (phase != (is_transparent ? DRAW_TRANSPARENT : DRAW_OPAQUE))
 			continue;
 
@@ -424,10 +424,8 @@ static void render_model(struct RE_instance *inst, struct RE_renderer *r, enum d
 			glActiveTexture(GL_TEXTURE0 + ALPHA_TEXTURE_UNIT);
 			glBindTexture(GL_TEXTURE_2D, material->alpha_map);
 			glUniform1i(r->alpha_texture, ALPHA_TEXTURE_UNIT);
-		} else if (material->flags & MATERIAL_SPRITE || mesh->flags & MESH_SPRITE) {
-			glUniform1i(r->alpha_mode, ALPHA_TEST);
 		} else {
-			glUniform1i(r->alpha_mode, ALPHA_BLEND);
+			glUniform1i(r->alpha_mode, mesh->is_transparent ? ALPHA_BLEND : ALPHA_TEST);
 		}
 
 		vec2 uv_scroll;


### PR DESCRIPTION
In ReignEngine, alpha blending is the default. Alpha testing is used if the mesh/material has the (sprite) attribute.

In TapirEngine, alpha testing is the default. Alpha blending is used if the mesh/material has the (alpha) attribute.