### PR TITLE
Fix "incomplete framebuffer" error in gfx_init_texture_rgb(a)

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -569,6 +569,8 @@ void gfx_init_texture_rgba(struct texture *t, int w, int h, SDL_Color color)
 		h = max_texture_size;
 	}
 	gfx_init_texture_blank(t, w, h);
+	if (w <= 0 || h <= 0)
+		return;
 	GLuint fbo = gfx_set_framebuffer(GL_DRAW_FRAMEBUFFER, t, 0, 0, w, h);
 	glClearColor(color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f);
 	glClear(GL_COLOR_BUFFER_BIT);
@@ -587,6 +589,8 @@ void gfx_init_texture_rgb(struct texture *t, int w, int h, SDL_Color color)
 	}
 	init_texture(t, w, h);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+	if (w <= 0 || h <= 0)
+		return;
 	GLuint fbo = gfx_set_framebuffer(GL_DRAW_FRAMEBUFFER, t, 0, 0, w, h);
 	glClearColor(color.r / 255.f, color.g / 255.f, color.b / 255.f, 255.f);
 	glClear(GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
This fixes "incomplete framebuffer" error in Haru Urare right after the game start, due to `gfx_set_framebuffer()` being called with a zero width texture. It was a regression introduced by commit 04d5237, which started using `gfx_set_framebuffer()` in `gfx_init_texture_rgba()`.

Ideally, we should avoid creating zero-area textures in upper layers (commit 3f18b18 was an attempt to do so), but this is difficult because there are many places that create textures. Let's just make sure that we don't generate unrecoverable errors.