### PR TITLE
Use RSM save format by default

### DIFF
--- a/include/xsystem4.h
+++ b/include/xsystem4.h
@@ -20,6 +20,11 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+enum resume_save_format {
+	SAVE_FORMAT_JSON,
+	SAVE_FORMAT_RSM,
+};
+
 struct config {
 	char *game_name;
 	char *ain_filename;
@@ -44,7 +49,7 @@ struct config {
 	bool echo;
 	float text_x_scale;
 	bool manual_text_x_scale;
-	bool rsm_save;
+	enum resume_save_format save_format;
 	int msgskip_delay;
 };
 

--- a/src/resume.c
+++ b/src/resume.c
@@ -411,10 +411,12 @@ static int save_json_image(const char *key, const char *path)
 
 int vm_save_image(const char *key, const char *path)
 {
-	if (config.rsm_save)
+	switch (config.save_format) {
+	case SAVE_FORMAT_RSM:
 		return save_rsave_image(key, path);
-	else
+	case SAVE_FORMAT_JSON:
 		return save_json_image(key, path);
+	}
 }
 
 #define _invalid_save_data(file, func, line, fmt, ...)	\
@@ -1020,8 +1022,10 @@ static int write_json_image_comments(const char *key, const char *path, struct p
 
 int vm_write_image_comments(const char *key, const char *path, struct page *comments)
 {
-	if (config.rsm_save)
+	switch (config.save_format) {
+	case SAVE_FORMAT_RSM:
 		return write_rsave_image_comments(key, path, comments);
-	else
+	case SAVE_FORMAT_JSON:
 		return write_json_image_comments(key, path, comments);
+	}
 }

--- a/src/system4.c
+++ b/src/system4.c
@@ -62,7 +62,7 @@ struct config config = {
 	.echo = false,
 	.text_x_scale = 1.0,
 	.manual_text_x_scale = false,
-	.rsm_save = false,
+	.save_format = SAVE_FORMAT_RSM,
 	.msgskip_delay = 0,
 
 	.bgi_path = NULL,
@@ -190,9 +190,9 @@ static void read_user_config_file(const char *path)
 			config.save_dir = xstrdup(ini_string(&ini[i])->text);
 		} else if (!strcmp(ini[i].name->text, "save-format")) {
 			if (!strcmp(ini_string(&ini[i])->text, "json")) {
-				config.rsm_save = false;
+				config.save_format = SAVE_FORMAT_JSON;
 			} else if (!strcmp(ini_string(&ini[i])->text, "rsm")) {
-				config.rsm_save = true;
+				config.save_format = SAVE_FORMAT_RSM;
 			} else {
 				WARNING("Invalid value for save-format in config: \"%s\"",
 						ini_string(&ini[i])->text);
@@ -506,9 +506,9 @@ int main(int argc, char *argv[])
 			break;
 		case LOPT_SAVE_FORMAT:
 			if (!strcmp(optarg, "json")) {
-				config.rsm_save = false;
+				config.save_format = SAVE_FORMAT_JSON;
 			} else if (!strcmp(optarg, "rsm")) {
-				config.rsm_save = true;
+				config.save_format = SAVE_FORMAT_RSM;
 			} else {
 				WARNING("Invalid value for --save-format option: \"%s\"", optarg);
 			}


### PR DESCRIPTION
Before this, the resume save format defaulted to JSON, which [could not be loaded by System40.exe](https://x.com/KanGT_f/status/1872635601314554105) and save/load was sometimes [too slow even on desktop environments](https://bsky.app/profile/kontaendless.itch.io/post/3lcsvkclurc2e).

In xsystem4-android the RSM format has been the default for 9 months and no problems have been reported. Let's make this the default on all platforms.