### PR TITLE
SystemService: Persist "wait vsync" setting to disk

### DIFF
--- a/include/savedata.h
+++ b/include/savedata.h
@@ -23,6 +23,7 @@
 void json_load_page(struct page *page, cJSON *vars, bool call_dtors);
 
 int save_json(const char *filename, cJSON *json);
+cJSON *load_json(const char *filename);
 int save_globals(const char *keyname, const char *filename, const char *group_name, int *n);
 int load_globals(const char *keyname, const char *filename, const char *group_name, int *n);
 int delete_save_file(const char *filename);

--- a/src/savedata.c
+++ b/src/savedata.c
@@ -67,7 +67,18 @@ int save_json(const char *filename, cJSON *json)
 	}
 	free(str);
 	return 1;
+}
 
+cJSON *load_json(const char *filename)
+{
+	char *path = savedir_path(filename);
+	char *json = file_read(path, NULL);
+	free(path);
+	if (!json)
+		return NULL;
+	cJSON *root = cJSON_Parse(json);
+	free(json);
+	return root;
 }
 
 static int get_group_index(const char *name)

--- a/src/video.c
+++ b/src/video.c
@@ -69,6 +69,7 @@ static struct texture *view = &main_surface;
 static GLint max_texture_size;
 static SDL_Color clear_color = { 0, 0, 0, 255 };
 static float frame_rate;
+static bool wait_vsync = false;
 
 static GLchar *read_shader_file(const char *path)
 {
@@ -267,7 +268,7 @@ int gfx_init(void)
 		ERROR("glewInit failed");
 #endif
 
-	SDL_GL_SetSwapInterval(0);
+	SDL_GL_SetSwapInterval(wait_vsync ? 1 : 0);
 	gl_initialize();
 	gfx_draw_init();
 	gfx_set_window_logical_size(config.view_width, config.view_height);
@@ -353,7 +354,9 @@ void gfx_update_screen_scale(void)
 
 void gfx_set_wait_vsync(bool wait)
 {
-	SDL_GL_SetSwapInterval(wait);
+	wait_vsync = wait;
+	if (gfx_initialized)
+		SDL_GL_SetSwapInterval(wait ? 1 : 0);
 }
 
 void gfx_set_clear_color(int r, int g, int b, int a)


### PR DESCRIPTION
This setting has a significant impact on system load, so users may want xsystem4 to remember their preference.

This implementation uses a JSON format, while the AliceSoft's implementation saves it to a binary file (`WindowSetting.sav`).

This only records the `wait_vsync` setting, since the other fields in `window_settings` are currently no-op.