### PR TITLE
StoatSpriteEngine: multisprite_update() should not use sprite_set_show()

### DIFF
--- a/game_compatibility.md
+++ b/game_compatibility.md
@@ -59,7 +59,7 @@ issues, please let me know or open a pull request to update this table.
 | エドランゼ ～Come on!水戸姫様～                         | Supported   |       |
 | 闘神都市III                                             | Supported   |       |
 | ばにしゅ！～おっぱいの消えた王国～                      | Unknown     |       |
-| 僕だけの保健室                                          | Unknown     |       |
+| 僕だけの保健室                                          | Supported   |       |
 | ももいろガーディアン                                    | Unknown     |       |
 | 超昂閃忍ハルカ ハルカVSエスカレイヤー                   | Unknown     | From Alice 2010 |
 | 超昂閃忍ハルカ ―疾風！？忍者大作戦―                     | Unknown     | From Alice 2010 |

--- a/src/hll/StoatSpriteEngine.c
+++ b/src/hll/StoatSpriteEngine.c
@@ -370,9 +370,9 @@ static void multisprite_update(struct multisprite *ms)
 		if (ms->cg) {
 			if (ms->type != 5)
 				sprite_set_cg_from_asset(&ms->sp, ms->cg);
-			sprite_set_show(&ms->sp, true);
 		} else {
-			sprite_set_show(&ms->sp, false);
+			// clear the texture
+			sprite_init_color(&ms->sp, 1, 1, 0, 0, 0, 0);
 		}
 		ms->cg_dirty = false;
 	}


### PR DESCRIPTION
`sprite_set_show()` is also used by `MultiSprite_SetAllShowMessageFrame`, causing interference.

Now `multisprite_update()` clears the sprite's texture when there's no CG, rather than hiding it.

Fixes #218.