### PR TITLE
Use case-insensitive match for asset file names

### DIFF
--- a/src/asset_manager.c
+++ b/src/asset_manager.c
@@ -334,7 +334,7 @@ void asset_manager_init(void)
 	// get ALD filenames
 	while ((d_name = readdir_utf8(dir))) {
 		// archive filename must begin with ain filename
-		if (strncmp(base, d_name, base_len))
+		if (strncasecmp(base, d_name, base_len))
 			goto loop_next;
 		const char *ext = file_extension(d_name);
 		if (!ext)


### PR DESCRIPTION
This fixes #227.

Rance 1 Digest Edition includes `Rance1.ain` and `RANCE1BA.ald`.