### PR TITLE
SACTDX/Stoat/Chipmunk: render sprites in correct order for same Z

### DIFF
--- a/include/sact.h
+++ b/include/sact.h
@@ -20,11 +20,19 @@
 #include <stdbool.h>
 #include "sprite.h"
 
+enum sprite_engine_type {
+	UNINITIALIZED_SPRITE_ENGINE,
+	SACT2_SPRITE_ENGINE,
+	SACTDX_SPRITE_ENGINE,
+	STOAT_SPRITE_ENGINE,
+	CHIPMUNK_SPRITE_ENGINE,
+};
+
 struct sact_sprite *sact_get_sprite(int sp);
 struct sact_sprite *sact_try_get_sprite(int sp);
 struct sact_sprite *sact_create_sprite(int sp_no, int width, int height, int r, int g, int b, int a);
 void sact_ModuleFini(void);
-int sact_init(int cg_cache_size, bool chipmunk);
+int sact_init(int cg_cache_size, enum sprite_engine_type engine);
 #define sact_SetWP scene_set_wp
 #define sact_SetWP_Color scene_set_wp_color
 int sact_GetScreenWidth(void);

--- a/src/hll/ChipmunkSpriteEngine.c
+++ b/src/hll/ChipmunkSpriteEngine.c
@@ -40,12 +40,12 @@ static void ChipmunkSpriteEngine_ModuleFini(void)
 
 static int ChipmunkSpriteEngine_Init(possibly_unused void *imain_system)
 {
-	return sact_init(16, true);
+	return sact_init(16, CHIPMUNK_SPRITE_ENGINE);
 }
 
 static int ChipmunkSpriteEngine_Init_with_size(possibly_unused void *imain_system, int cg_cache_size)
 {
-	return sact_init(cg_cache_size, true);
+	return sact_init(cg_cache_size, CHIPMUNK_SPRITE_ENGINE);
 }
 
 static int ChipmunkSpriteEngine_SP_SetCG(int sp_no, struct string *cg_name)

--- a/src/hll/StoatSpriteEngine.c
+++ b/src/hll/StoatSpriteEngine.c
@@ -313,7 +313,7 @@ static void multisprite_reset_cg(struct multisprite *sp)
 
 static int StoatSpriteEngine_Init(void *imain_system, int cg_cache_size)
 {
-	sact_init(cg_cache_size, false);
+	sact_init(cg_cache_size, STOAT_SPRITE_ENGINE);
 	for (int i = 0; i < NR_SP_TYPES; i++) {
 		sp_types[i].nr_sprites = 16;
 		sp_types[i].sprites = xcalloc(16, sizeof(struct multisprite*));

--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -913,7 +913,7 @@ bool PE_Init(void)
 	if (parts_engine_initialized)
 		return true;
 	// XXX: Oyako Rankan doesn't call ChipmunkSpriteEngine.Init
-	sact_init(16, true);
+	sact_init(16, CHIPMUNK_SPRITE_ENGINE);
 	parts_table = ht_create(1024);
 	parts_render_init();
 	parts_debug_init();


### PR DESCRIPTION
In SACT2, if two sprites have the same Z value, they are rendered in increasing order of their sprite numbers. This behavior is documented in the SDK manual.

However, in later versions of the sprite engine (SACTDX, StoatSpriteEngine, ChipmunkSpriteEngine), sprites are drawn in the order they were created.

This fixes an issue in Rance Quest Magnum which relies on this behavior.

![RQM-z-order-bug](https://github.com/user-attachments/assets/0639c7a2-a412-4476-9c1a-1ff160cafc70)
("ランスアタック" is shown above "初動LOCK")