### PR TITLE
Fix overlapping text issue in MangaGamer Sengoku Rance

### DIFF
--- a/src/hll/DrawGraph.c
+++ b/src/hll/DrawGraph.c
@@ -18,6 +18,7 @@
 #include "sact.h"
 #include "gfx/gfx.h"
 #include "gfx/font.h"
+#include "xsystem4.h"
 #include "system4/string.h"
 
 // Get texture for source sprite
@@ -165,6 +166,10 @@ static void DrawGraph_FillAlphaColor(int dst, int x, int y, int w, int h, int r,
 static void DrawGraph_FillAMap(int dst, int x, int y, int w, int h, int alpha)
 {
 	gfx_fill_amap(DTEX(dst), x, y, w, h, alpha);
+	if (game_rance7_mg) {
+		// Short-term fix for https://github.com/nunuhara/xsystem4/issues/237
+		sprite_text_clear(sact_get_sprite(dst));
+	}
 }
 
 static void DrawGraph_FillAMapOverBorder(int dst, int x, int y, int w, int h, int alpha, int border)


### PR DESCRIPTION
This fixes https://github.com/kichikuou/xsystem4-android/issues/12.

This game uses `DrawGraph.FillAMap()` to erase text drawn on the sprite, but our SengokuRanceFont implementation draws text on `sp->text.texture`.

For a detailed analysis of this issue and other possible solutions, see https://github.com/nunuhara/xsystem4/issues/237.