### PR TITLE
parts: Implement PE_AddWholeMotionVibrationSize

### DIFF
--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -32,6 +32,7 @@
 struct parts_list parts_list = TAILQ_HEAD_INITIALIZER(parts_list);
 static struct parts_list dirty_list = TAILQ_HEAD_INITIALIZER(dirty_list);
 static struct hash_table *parts_table = NULL;
+static Point root_pos = { 0, 0 };
 
 #define PARTS_PARAMS_INITIALIZER (struct parts_params) { \
 	.z = 1, \
@@ -357,8 +358,18 @@ void parts_set_pos(struct parts *parts, Point pos)
 	parts->local.pos.x = pos.x;
 	parts->local.pos.y = pos.y;
 	parts_recalculate_hitbox(parts);
-	parts_update_global_pos(parts, parts->parent ? parts->parent->global.pos : (Point){0,0});
+	parts_update_global_pos(parts, parts->parent ? parts->parent->global.pos : root_pos);
 	parts_dirty(parts);
+}
+
+void parts_set_global_pos(Point pos)
+{
+	root_pos = pos;
+	struct parts *parts;
+	PARTS_LIST_FOREACH(parts) {
+		parts_update_global_pos(parts, root_pos);
+	}
+	parts_engine_dirty();
 }
 
 static void parts_update_global_z(struct parts *parts, int parent_z)

--- a/src/parts/parts_internal.h
+++ b/src/parts/parts_internal.h
@@ -70,6 +70,8 @@ struct parts_motion {
 	int end_time;
 };
 
+TAILQ_HEAD(parts_motion_list, parts_motion);
+
 struct sound_motion {
 	TAILQ_ENTRY(sound_motion) entry;
 	int begin_time;
@@ -323,7 +325,7 @@ struct parts {
 	int linked_from;
 	int draw_filter;
 	bool message_window;
-	TAILQ_HEAD(, parts_motion) motion;
+	struct parts_motion_list motion;
 };
 
 #define PARTS_LIST_FOREACH(iter) TAILQ_FOREACH(iter, &parts_list, parts_list_entry)
@@ -342,6 +344,7 @@ struct parts_gauge *parts_get_vgauge(struct parts *parts, int state);
 struct parts_construction_process *parts_get_construction_process(struct parts *parts, int state);
 struct parts_flash *parts_get_flash(struct parts *parts, int state);
 void parts_set_pos(struct parts *parts, Point pos);
+void parts_set_global_pos(Point pos);
 void parts_set_dims(struct parts *parts, struct parts_common *common, int w, int h);
 void parts_set_scale_x(struct parts *parts, float mag);
 void parts_set_scale_y(struct parts *parts, float mag);


### PR DESCRIPTION
It vibrates the whole screen. To implement this, this introduces a global motion list and parts_set_global_pos(), which sets the position of the root of the parts tree.