### PR TITLE
Fix bool return value of HLL functions

### DIFF
--- a/src/ffi.c
+++ b/src/ffi.c
@@ -385,14 +385,21 @@ void hll_call(int libno, int fno)
 		}
 	}
 
-	if (f->return_type.data != AIN_VOID) {
-		if (f->return_type.data == AIN_STRING) {
-			int slot = heap_alloc_slot(VM_STRING);
-			heap[slot].s = r.ref;
-			stack_push(slot);
-		} else {
-			stack_push(r);
-		}
+	int slot;
+	switch (f->return_type.data) {
+	case AIN_VOID:
+		break;
+	case AIN_STRING:
+		slot = heap_alloc_slot(VM_STRING);
+		heap[slot].s = r.ref;
+		stack_push(slot);
+		break;
+	case AIN_BOOL:
+		stack_push(*(bool*)&r);
+		break;
+	default:
+		stack_push(r);
+		break;
 	}
 }
 


### PR DESCRIPTION
Since bool functions return a 1-byte value, the value of the upper 24 bits of `r.i` after `ffi_call` is undefined.

This actually led to a bug where `PassRegister.ExistText` returned incorrect values on Windows x64.