### PR TITLE
Update game compatibility table

### DIFF
--- a/game_compatibility.md
+++ b/game_compatibility.md
@@ -74,7 +74,8 @@ issues, please let me know or open a pull request to update this table.
 | Rance 02 -The Rebellious Maidens- (MangaGamer)          | Supported   |       |
 | しゃーまんず・さんくちゅあり－巫女の聖域－              | Unknown     |       |
 | 大帝国                                                  | Supported   |       |
-| ランス・クエスト                                        | Unsupported |       |
+| ランス・クエスト                                        | Supported   |       |
+| ランス・クエスト マグナム                               | Supported   |       |
 | 母娘乱館                                                | Unknown     |       |
 | パステルチャイム3 バインドシーカー                      | Unsupported |       |
 | どらぺこ！ ～おねだりドラゴンとおっぱい勇者～           | Unsupported |       |


### PR DESCRIPTION
Marking Rance Quest and Rance Quest Magnum as supported.

I was able to clear Rance Quest Magnum Integrated Edition (TADA patch v3.86E) without any issues.

I have only played the first few quests of the original Rance Quest, but I think it is safe to say that it works.

Fixes #209.