### PR TITLE
SystemService: Implement playing manual

### DIFF
--- a/src/hll/SystemService.c
+++ b/src/hll/SystemService.c
@@ -295,6 +295,7 @@ static bool SystemService_IsExistPlayingManual(void) {
 	return exists;
 }
 
+#ifndef _WIN32
 static char *percent_encode(const char *str) {
 	const char *hex = "0123456789ABCDEF";
 	// Worst case all characters are percent-encoded
@@ -318,6 +319,7 @@ static char *percent_encode(const char *str) {
 	*p = '\0';
 	return encoded;
 }
+#endif
 
 static void SystemService_OpenPlayingManual(void) {
 	if (!SystemService_IsExistPlayingManual()) {
@@ -331,7 +333,6 @@ static void SystemService_OpenPlayingManual(void) {
 	if (!real_path) {
 		return;
 	}
-
 
 #ifdef _WIN32
 	const char *prefix = "file:///";


### PR DESCRIPTION
## Summary
Adds the ability to open game manuals from within the application by implementing the functions SystemService_IsExistPlayingManual and SystemService_OpenPlayingManual.

## Fixes
Fixes a crash when pressing the manual button in Rance 01.

## Windows and linux differences
The SDL_OpenURL function uses ShellExecuteW under the hood on windows. Which didn't work well with percent encoded paths but did work without percent encoding. Linux expected percent-encoding and would fail on certain paths if it was not percent encoded.

## Testing
This feature was tested and confirmed to work as expected on:
- Windows
- Linux

## Known Limitations

- Android: This implementation will not work on Android, as the platform's security model and browser restrictions prevent the use of file:// URLs. On Android, this function will currently do nothing besides log a warning.