### PR TITLE
3d: Ensure shader fragment ends with a newline

### DIFF
--- a/src/3d/renderer.c
+++ b/src/3d/renderer.c
@@ -66,7 +66,7 @@ static GLuint load_shader(const char *vertex_shader_path, const char *fragment_s
 	snprintf(defines, sizeof(defines),
 			 "#define REIGN_ENGINE %d\n"
 			 "#define TAPIR_ENGINE %d\n"
-			 "#define ENGINE %d",
+			 "#define ENGINE %d\n",
 			 RE_REIGN_PLUGIN,
 			 RE_TAPIR_PLUGIN,
 			 re_plugin_version);


### PR DESCRIPTION
The `defines` string in load_shader() is prepended to the glsl file, but it was not terminated with a newline, so the resulting shader source looked like this:

    #define REIGN_ENGINE 0
    #define TAPIR_ENGINE 1
    #define ENGINE 1/* Copyright (C) ...
     *
     * This program is free software; ...
    ...

This confused some OpenGL ES implementations, causing a syntax error. https://github.com/kichikuou/xsystem4-android/issues/15