### PR TITLE
Do not call destructors for structs passed by value to HLL functions

### DIFF
--- a/include/vm/page.h
+++ b/include/vm/page.h
@@ -103,7 +103,7 @@ static inline void _page_set_var(struct page *page, int i, union vm_value v)
 
 // variables
 union vm_value variable_initval(enum ain_data_type type);
-void variable_fini(union vm_value v, enum ain_data_type type);
+void variable_fini(union vm_value v, enum ain_data_type type, bool call_dtor);
 enum ain_data_type variable_type(struct page *page, int varno, int *struct_type, int *array_rank);
 void variable_set(struct page *page, int varno, enum ain_data_type type, union vm_value val);
 

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -380,7 +380,7 @@ void hll_call(int libno, int fno)
 				break;
 			// fallthrough
 		default:
-			variable_fini(stack[stack_ptr+j], f->arguments[i].type.data);
+			variable_fini(stack[stack_ptr+j], f->arguments[i].type.data, false);
 			break;
 		}
 	}

--- a/src/hll/File.c
+++ b/src/hll/File.c
@@ -62,7 +62,7 @@ static void read_value(union vm_value *v, enum ain_data_type type)
 		v->f = buffer_read_float(&contents);
 		break;
 	case AIN_STRING:
-		variable_fini(*v, type);
+		variable_fini(*v, type, true);
 		v->i = heap_alloc_string(buffer_read_string(&contents));
 		break;
 	case AIN_STRUCT:

--- a/src/hll/vmFile.c
+++ b/src/hll/vmFile.c
@@ -58,7 +58,7 @@ static void read_value(struct vm_file *vf, union vm_value *v, enum ain_data_type
 		v->f = buffer_read_float(&vf->buf);
 		break;
 	case AIN_STRING:
-		variable_fini(*v, type);
+		variable_fini(*v, type, true);
 		v->i = heap_alloc_string(buffer_read_string(&vf->buf));
 		break;
 	case AIN_STRUCT:

--- a/src/vm.c
+++ b/src/vm.c
@@ -421,7 +421,7 @@ static void delegate_call(int dg_no, int return_address)
 		stack_pop(); // dg_index
 		stack_pop(); // dg_page
 		for (int i = ain->delegates[dg_no].nr_variables - 1; i >= 0; i--) {
-			variable_fini(stack_pop(), ain->delegates[dg_no].variables[i].type.data);
+			variable_fini(stack_pop(), ain->delegates[dg_no].variables[i].type.data, true);
 		}
 		if (return_values) {
 			stack_push(r);


### PR DESCRIPTION
Some classes in Dungeons & Dolls serialize themselves using `File.Write(this)` in their destructors. Because `File.Write` takes the argument by value, a copy of `this` is created. If the destructor is called on the copied `this`, it falls into an an infinite loop.