### PR TITLE
Dungeons & Dolls: Call global variable destructors on exit

### DIFF
--- a/include/xsystem4.h
+++ b/include/xsystem4.h
@@ -91,5 +91,6 @@ extern bool game_rance02_mg;
 extern bool game_rance6_mg;
 extern bool game_rance7_mg;
 extern bool game_rance8;
+extern bool game_dungeons_and_dolls;
 
 #endif /* XSYSTEM4_H */

--- a/src/hacks.c
+++ b/src/hacks.c
@@ -37,6 +37,7 @@ bool game_rance02_mg = false;
 bool game_rance6_mg = false;
 bool game_rance7_mg = false;
 bool game_rance8 = false;
+bool game_dungeons_and_dolls = false;
 
 static void write_instruction0(struct buffer *out, enum opcode op)
 {
@@ -205,6 +206,8 @@ void apply_game_specific_hacks(struct ain *ain)
 		apply_rance7_hacks(ain);
 	} else if (!strcmp(game_name, "ランス・クエスト") || !strcmp(game_name, "Rance Quest")) {
 		game_rance8 = true;
+	} else if (!strcmp(game_name, "ＤＵＮＧＥＯＮＳ＆ＤＯＬＬＳ")) {
+		game_dungeons_and_dolls = true;
 	}
 	free(game_name);
 }


### PR DESCRIPTION
Early versions of System4 (`Sys42VM.dll` < 3.0) execute destructors for global variables on exit.

Dungeons & Dolls saves its game state in the destructors of global variables (`~CDataDoll()`, `~CDataItem()`, `~CDataMain()`), so the game was not saved in xsystem4 before this.

This behavior has some quirks:
 * Destructors for variables on the call stack are not called on exit.
 * Destructors are called in the reverse order of the global variable declarations.
 * Inside a destructor, it is possible to access another global variable whose destructor has already been called (!).

Since this is a problematic behavior that was removed in later versions of Sys42VM, let's add minimal support for it as a game-specific hack.