### PR TITLE
DrawDungeon: Implement light mapping

### DIFF
--- a/include/dungeon/dgn.h
+++ b/include/dungeon/dgn.h
@@ -45,7 +45,13 @@ struct dgn_cell {
 	int32_t west_door;
 	int32_t stairs_texture;
 	int32_t stairs_orientation;
-	// int32_t unknown[13];
+	int32_t lightmap_floor;
+	int32_t lightmap_ceiling;
+	int32_t lightmap_north;
+	int32_t lightmap_south;
+	int32_t lightmap_east;
+	int32_t lightmap_west;
+	// int32_t unknown[7];
 	int32_t enterable;
 	int32_t enterable_north;
 	int32_t enterable_south;

--- a/include/dungeon/dtx.h
+++ b/include/dungeon/dtx.h
@@ -23,13 +23,18 @@
 struct cg;
 
 enum dtx_texture_type {
-	DTX_WALL = 0,
-	DTX_FLOOR = 1,
-	DTX_CEILING = 2,
-	DTX_STAIRS = 3,
-	DTX_DOOR = 4,
-	DTX_SKYBOX = 5,
+	// cell textures
+	DTX_WALL,
+	DTX_FLOOR,
+	DTX_CEILING,
+	DTX_STAIRS,
+	DTX_DOOR,
+	DTX_LIGHTMAP,
+	// skybox textures
+	DTX_SKYBOX,
 };
+
+#define DTX_NR_CELL_TEXTURE_TYPES (DTX_LIGHTMAP + 1)
 
 struct dtx_entry {
 	uint32_t size;
@@ -45,7 +50,7 @@ struct dtx {
 
 struct dtx *dtx_parse(uint8_t *data, size_t size);
 void dtx_free(struct dtx *dtx);
-struct cg *dtx_create_cg(struct dtx *dtx, int type, int index);
+struct cg *dtx_create_cg(struct dtx *dtx, enum dtx_texture_type type, int index);
 struct dtx *dtx_load_from_dtl(const char *path, uint32_t seed);
 
 #endif /* SYSTEM4_DTX_H */

--- a/shaders/dungeon.f.glsl
+++ b/shaders/dungeon.f.glsl
@@ -15,6 +15,8 @@
  */
 
 uniform sampler2D tex;
+uniform sampler2D light_texture;
+uniform bool use_lightmap;
 uniform float alpha_mod;
 
 in float dist;
@@ -26,7 +28,11 @@ const vec3 FOG_COLOR = vec3(0.0, 0.0, 0.0);
 
 void main() {
         vec4 texel = texture(tex, tex_coord);
+        float light_factor = 1.0;
+        if (use_lightmap) {
+                light_factor = texture(light_texture, tex_coord).a;
+        }
         float fog_factor = (FOG_MAX_DIST - dist) / FOG_MAX_DIST;
         fog_factor = clamp(fog_factor, 0.3, 1.0);
-        frag_color = vec4(mix(FOG_COLOR, vec3(texel), fog_factor), texel.a * alpha_mod);
+        frag_color = vec4(mix(FOG_COLOR, texel.rgb * light_factor, fog_factor), texel.a * alpha_mod);
 }

--- a/src/dungeon/dgn.c
+++ b/src/dungeon/dgn.c
@@ -73,7 +73,13 @@ struct dgn *dgn_parse(uint8_t *data, size_t size)
 		cell->west_door = buffer_read_int32(&r);
 		cell->stairs_texture = buffer_read_int32(&r);
 		cell->stairs_orientation = buffer_read_int32(&r);
-		buffer_skip(&r, 13 * 4);
+		cell->lightmap_floor = buffer_read_int32(&r);
+		cell->lightmap_ceiling = buffer_read_int32(&r);
+		cell->lightmap_north = buffer_read_int32(&r);
+		cell->lightmap_south = buffer_read_int32(&r);
+		cell->lightmap_east = buffer_read_int32(&r);
+		cell->lightmap_west = buffer_read_int32(&r);
+		buffer_skip(&r, 7 * 4);
 		cell->enterable = buffer_read_int32(&r);
 		cell->enterable_north = buffer_read_int32(&r);
 		cell->enterable_south = buffer_read_int32(&r);
@@ -544,6 +550,12 @@ struct dgn *dgn_generate_drawdungeon2(int level)
 			cell->west_door = -1;
 			cell->stairs_texture = -1;
 			cell->stairs_orientation = -1;
+			cell->lightmap_floor = -1;
+			cell->lightmap_ceiling = -1;
+			cell->lightmap_north = -1;
+			cell->lightmap_south = -1;
+			cell->lightmap_east = -1;
+			cell->lightmap_west = -1;
 			cell->enterable = 0;
 			cell->enterable_north = 0;
 			cell->enterable_south = 0;

--- a/src/dungeon/dtx.c
+++ b/src/dungeon/dtx.c
@@ -73,11 +73,23 @@ void dtx_free(struct dtx *dtx)
 	free(dtx);
 }
 
-struct cg *dtx_create_cg(struct dtx *dtx, int type, int index)
+struct cg *dtx_create_cg(struct dtx *dtx, enum dtx_texture_type type, int index)
 {
-	if (type < 0 || type >= dtx->nr_rows || index < 0 || index >= dtx->nr_columns)
+	int row;
+	switch (type) {
+	case DTX_WALL:     row = 0; break;
+	case DTX_FLOOR:    row = 1; break;
+	case DTX_CEILING:  row = 2; break;
+	case DTX_STAIRS:   row = 3; break;
+	case DTX_DOOR:     row = 4; break;
+	case DTX_SKYBOX:   row = 5; break;
+	case DTX_LIGHTMAP: row = dtx->version == 0 ? 6 : 7; break;
+	default:
 		return NULL;
-	struct dtx_entry *entry = &dtx->entries[type * dtx->nr_columns + index];
+	}
+	if (index < 0 || index >= dtx->nr_columns)
+		return NULL;
+	struct dtx_entry *entry = &dtx->entries[row * dtx->nr_columns + index];
 	if (!entry->data)
 		return NULL;
 	return cg_load_buffer(entry->data, entry->size);


### PR DESCRIPTION
Without this:
<img width="1284" height="1024" alt="without-lightmap" src="https://github.com/user-attachments/assets/e3b1763e-6c8a-4e46-b515-d4569ec55838" />

With this (look at the border between the wall and floor):
<img width="1284" height="1024" alt="with-lightmap" src="https://github.com/user-attachments/assets/6a516ec9-0b1c-4b82-9b8f-0450819f403b" />
