### PR TITLE
fix: Y origin in prepare_chipmunk_shader

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -109,8 +109,9 @@ static void prepare_chipmunk_shader(struct gfx_render_job *job, void *data)
 		r = (Rectangle) { 0, 0, sp->rect.w, sp->rect.h };
 	}
 
-	glUniform2f(s->bot_left, r.x, r.y);
-	glUniform2f(s->top_right, r.x + r.w, r.y + r.h);
+	int sy_bottom = sp->rect.h - (r.y + r.h);
+	glUniform2f(s->bot_left,  r.x, sy_bottom);
+	glUniform2f(s->top_right, r.x + r.w, sy_bottom + r.h);
 }
 
 void sprite_init_sact(void)


### PR DESCRIPTION
## Summary
The parts.f.glsl expects clip coordinates (`bot_left`/`top_right`) in bottom-left UV space, but `surface_area(x,y,w,h)` is stored in top-left sprite-local pixels. We were uploading TL values directly, so partial crops were clipped at the wrong vertical position. This in turn broke the Magnum Gauge in Rance Quest Magnum

## Fix
Flip the surface_area.y inside the sprite's local rect before uploading it to the shader. (TL -> BL);
##
Without this:
<img width="1024" height="768" src="https://github.com/user-attachments/assets/7ef8bfe9-90f5-4c1f-9a63-525a5190750c" />
With this:
<img width="1024" height="768" src="https://github.com/user-attachments/assets/0dc43ad0-7586-4d3d-887c-828d569d2c3e" />

