### PR TITLE
Pastel Chime Continue: Add DrawField HLL

### DIFF
--- a/include/dungeon/dgn.h
+++ b/include/dungeon/dgn.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <cglm/cglm.h>
 
 /*
  * Dungeon data is a collection of cells indexed by three integers (x, y, z).
@@ -92,6 +93,10 @@ struct dgn_cell {
 	float south_door_angle;
 	float east_door_angle;
 	float west_door_angle;
+	int north_door_lock;
+	int south_door_lock;
+	int east_door_lock;
+	int west_door_lock;
 	int32_t floor_event2;
 	int32_t north_event2;
 	int32_t south_event2;
@@ -113,19 +118,28 @@ struct packed_pvs {
 };
 
 struct dgn {
-	uint32_t version; // 10: Rance VI, 13: GALZOO Island
+	uint32_t version;
 	uint32_t size_x;
 	uint32_t size_y;
 	uint32_t size_z;
 	// uint32_t unknown[10];
 	struct dgn_cell *cells;
 	struct packed_pvs *pvs;
+	vec3 sphere_theta;
+	float sphere_color_top;
+	float sphere_color_bottom;
 
-	int start_x, start_y; // DrawDungeon2
-	int exit_x, exit_y; // DrawDungeon2
+	// DrawDungeon2
+	int start_x, start_y;
+	int exit_x, exit_y;
+
+	// DrawField
+	int32_t back_color_r;
+	int32_t back_color_g;
+	int32_t back_color_b;
 };
 
-struct dgn *dgn_parse(uint8_t *data, size_t size);
+struct dgn *dgn_parse(uint8_t *data, size_t size, bool for_draw_field);
 void dgn_free(struct dgn *dgn);
 
 int dgn_cell_index(struct dgn *dgn, uint32_t x, uint32_t y, uint32_t z);

--- a/include/dungeon/dungeon.h
+++ b/include/dungeon/dungeon.h
@@ -20,8 +20,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <cglm/cglm.h>
 #include "gfx/gfx.h"
 #include "plugin.h"
+
+#define DRAWFIELD_NR_CHARACTERS 256
 
 struct page;
 struct dgn;
@@ -29,11 +32,13 @@ struct dtx;
 struct tes;
 struct dungeon_renderer;
 struct dungeon_map;
+struct drawfield_character;
 
 enum draw_dungeon_version {
 	DRAW_DUNGEON_1,    // Rance VI
 	DRAW_DUNGEON_2,    // Dungeons & Dolls
-	DRAW_DUNGEON_14    // GALZOO Island
+	DRAW_DUNGEON_14,   // GALZOO Island
+	DRAW_FIELD         // Pastel Chime Continue
 };
 
 struct camera {
@@ -62,6 +67,9 @@ struct dungeon_context {
 	struct dgn *dgn;
 	struct dtx *dtx;
 	struct tes *tes;
+	ivec3 player_pos;
+	struct drawfield_character *characters;
+	mat4 proj_transform;
 	struct dungeon_renderer *renderer;
 	struct texture texture;
 	GLuint depth_buffer;
@@ -69,7 +77,11 @@ struct dungeon_context {
 
 struct dungeon_context *dungeon_context_create(enum draw_dungeon_version version, int width, int height);
 bool dungeon_load(struct dungeon_context *ctx, int num);
+bool dungeon_load_dungeon(struct dungeon_context *ctx, const char *filename, int num);
+bool dungeon_load_texture(struct dungeon_context *ctx, const char *filename);
 void dungeon_set_camera(int surface, float x, float y, float z, float angle, float angle_p);
+void dungeon_set_perspective(int surface, int width, int height, float near, float far, float deg);
+void dungeon_set_player_pos(int surface, int x, int y, int z);
 void dungeon_set_walked(int surface, int x, int y, int z, int flag);
 int dungeon_get_walked(int surface, int x, int y, int z);
 void dungeon_set_walked_all(int surface);
@@ -77,6 +89,11 @@ int dungeon_calc_conquer(int surface);
 bool dungeon_load_walk_data(int surface, int map, struct page **page);
 bool dungeon_save_walk_data(int surface, int map, struct page **page);
 void dungeon_paint_step(int surface, int x, int y, int z);
+void dungeon_set_chara_sprite(int surface, int num, int sprite);
+void dungeon_set_chara_pos(int surface, int num, float x, float y, float z);
+void dungeon_set_chara_cg(int surface, int num, int cg);
+void dungeon_set_chara_cg_info(int surface, int num, int num_chara_x, int num_chara_y);
+void dungeon_set_chara_show(int surface, int num, bool show);
 
 struct dungeon_context *dungeon_get_context(int surface);
 

--- a/include/dungeon/map.h
+++ b/include/dungeon/map.h
@@ -32,6 +32,7 @@ void dungeon_map_set_all_view(int surface, int flag);
 void dungeon_map_set_cg(int surface, int index, int sprite);
 void dungeon_map_set_small_map_floor(int surface, int floor);
 void dungeon_map_set_large_map_floor(int surface, int floor);
-void dungeon_map_reveal(struct dungeon_context *ctx, int x, int y, int z, bool transparent);
+void dungeon_map_reveal(struct dungeon_context *ctx, int x, int y, int z, bool from_walk_data);
+void dungeon_map_hide(struct dungeon_context *ctx, int x, int y, int z);
 
 #endif /* SYSTEM4_DUNGEON_MAP_H */

--- a/include/dungeon/renderer.h
+++ b/include/dungeon/renderer.h
@@ -26,14 +26,26 @@ struct dtx;
 struct polyobj;
 struct dungeon_renderer;
 
+struct drawfield_character {
+	vec3 pos;
+	int sprite;
+	int rows;
+	int cols;
+	int cg_index;
+	bool show;
+};
+
 struct dungeon_renderer *dungeon_renderer_create(enum draw_dungeon_version version, int num, struct dtx *dtx, GLuint *event_textures, int nr_event_textures, struct polyobj *po);
 void dungeon_renderer_free(struct dungeon_renderer *r);
-void dungeon_renderer_render(struct dungeon_renderer *r, struct dgn_cell **cells, int nr_cells, mat4 view_transform, mat4 proj_transform);
+void dungeon_renderer_render(struct dungeon_renderer *r, struct dgn_cell **cells, int nr_cells, struct drawfield_character *characters, mat4 view_transform, mat4 proj_transform);
 void dungeon_renderer_enable_event_markers(struct dungeon_renderer *r, bool enable);
 bool dungeon_renderer_event_markers_enabled(struct dungeon_renderer *r);
 bool dungeon_renderer_is_floor_opaque(struct dungeon_renderer *r, struct dgn_cell *cell);
 void dungeon_renderer_run_post_processing(struct dungeon_renderer *r, struct texture *src, struct texture *dst);
 void dungeon_renderer_set_raster_scroll(struct dungeon_renderer *r, int type);
 void dungeon_renderer_set_raster_amp(struct dungeon_renderer *r, float amp);
+void dungeon_renderer_enable_lightmap(struct dungeon_renderer *r, bool enable);
+bool dungeon_renderer_get_draw_obj_flag(struct dungeon_renderer *r, int type);
+void dungeon_renderer_set_draw_obj_flag(struct dungeon_renderer *r, int type, bool flag);
 
 #endif /* SYSTEM4_DUNGEON_RENDERER_H */

--- a/shaders/dungeon.f.glsl
+++ b/shaders/dungeon.f.glsl
@@ -18,6 +18,7 @@ uniform sampler2D tex;
 uniform sampler2D light_texture;
 uniform bool use_lightmap;
 uniform float alpha_mod;
+uniform bool use_fog;
 
 in float dist;
 in vec2 tex_coord;
@@ -32,7 +33,14 @@ void main() {
         if (use_lightmap) {
                 light_factor = texture(light_texture, tex_coord).a;
         }
-        float fog_factor = (FOG_MAX_DIST - dist) / FOG_MAX_DIST;
-        fog_factor = clamp(fog_factor, 0.3, 1.0);
-        frag_color = vec4(mix(FOG_COLOR, texel.rgb * light_factor, fog_factor), texel.a * alpha_mod);
+        if (use_fog) {
+                float fog_factor = (FOG_MAX_DIST - dist) / FOG_MAX_DIST;
+                fog_factor = clamp(fog_factor, 0.3, 1.0);
+                frag_color = vec4(mix(FOG_COLOR, texel.rgb * light_factor, fog_factor), texel.a * alpha_mod);
+        } else {
+                if (texel.a < 0.01) {
+                        discard;
+                }
+                frag_color = vec4(texel.rgb * light_factor, texel.a * alpha_mod);
+        }
 }

--- a/shaders/dungeon.v.glsl
+++ b/shaders/dungeon.v.glsl
@@ -17,6 +17,8 @@
 uniform mat4 local_transform;
 uniform mat4 view_transform;
 uniform mat4 proj_transform;
+uniform vec2 uv_offset;
+uniform vec2 uv_scale;
 
 in vec3 vertex_pos;
 in vec2 vertex_uv;
@@ -27,5 +29,5 @@ void main() {
         vec4 pos = view_transform * local_transform * vec4(vertex_pos, 1.0);
         dist = abs(pos.z);
         gl_Position = proj_transform * pos;
-        tex_coord = vertex_uv;
+        tex_coord = vertex_uv * uv_scale + uv_offset;
 }

--- a/src/dungeon/skybox.c
+++ b/src/dungeon/skybox.c
@@ -36,8 +36,8 @@ struct skybox {
 
 struct skybox *skybox_create(enum draw_dungeon_version version, struct dtx *dtx)
 {
-	if (version == DRAW_DUNGEON_2) {
-		// Skybox is not used in Dungeons & Dolls.
+	if (version == DRAW_DUNGEON_2 || version == DRAW_FIELD) {
+		// Skybox is not used in these games.
 		return NULL;
 	};
 

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -436,6 +436,7 @@ extern struct static_library lib_DrawDungeon;
 extern struct static_library lib_DrawDungeon2;
 extern struct static_library lib_DrawDungeon14;
 extern struct static_library lib_DrawEffect;
+extern struct static_library lib_DrawField;
 extern struct static_library lib_DrawGraph;
 extern struct static_library lib_DrawMovie;
 extern struct static_library lib_DrawMovie2;
@@ -549,6 +550,7 @@ static struct static_library *static_libraries[] = {
 	&lib_DrawDungeon2,
 	&lib_DrawDungeon14,
 	&lib_DrawEffect,
+	&lib_DrawField,
 	&lib_DrawGraph,
 	&lib_DrawMovie,
 	&lib_DrawMovie2,

--- a/src/hll/DrawDungeon.c
+++ b/src/hll/DrawDungeon.c
@@ -17,8 +17,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <math.h>
 
 #include "system4.h"
+#include "system4/string.h"
 
 #include "dungeon/dgn.h"
 #include "dungeon/dungeon.h"
@@ -62,6 +64,11 @@ static int DrawDungeon14_Init(int surface)
 	return dungeon_init(DRAW_DUNGEON_14, surface);
 }
 
+static int DrawField_Init(int surface)
+{
+	return dungeon_init(DRAW_FIELD, surface);
+}
+
 static void DrawDungeon_Release(int surface)
 {
 	if (!dungeon_get_context(surface))
@@ -75,6 +82,14 @@ static void DrawDungeon_SetDrawFlag(int surface, int flag)
 	if (!ctx)
 		return;
 	ctx->draw_enabled = flag;
+}
+
+static bool DrawDungeon_GetDrawFlag(int surface)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx)
+		return false;
+	return ctx->draw_enabled;
 }
 
 static bool DrawDungeon_BeginLoad(int surface, int num)
@@ -99,8 +114,23 @@ static bool DrawDungeon_IsSucceededLoading(int surface)
 }
 
 //float DrawDungeon_GetLoadingPercent(int surface);
-//int DrawDungeon_LoadFromFile(int surface, struct string *file_name, int num);
-//int DrawDungeon_LoadTexture(int surface, struct string *file_name);
+
+static int DrawDungeon_LoadFromFile(int surface, struct string *file_name, int num)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx)
+		return false;
+	return dungeon_load_dungeon(ctx, file_name->text, num);
+}
+
+static int DrawDungeon_LoadTexture(int surface, struct string *file_name)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx)
+		return false;
+	return dungeon_load_texture(ctx, file_name->text);
+}
+
 //int DrawDungeon_LoadEventTexture(int surface, struct string *file_name);
 
 static int DrawDungeon_GetMapX(int surface)
@@ -248,6 +278,7 @@ HLL_QUIET_UNIMPLEMENTED(0, int,  DrawDungeon, GetDrawHalfFlag, int surface);
 //int DrawDungeon_CalcNumofWalk2(int surface);
 HLL_QUIET_UNIMPLEMENTED( , void, DrawDungeon, SetInterlaceMode, int surface, int flag);
 HLL_QUIET_UNIMPLEMENTED(1, bool, DrawDungeon, SetDirect3DMode, int surface, int flag);
+HLL_QUIET_UNIMPLEMENTED(1, bool, DrawDungeon, GetDirect3DMode, int surface);
 HLL_QUIET_UNIMPLEMENTED( , void, DrawDungeon, SaveDrawSettingFlag, int direct3D, int interlace, int half);
 HLL_QUIET_UNIMPLEMENTED( , void, DrawDungeon, GetDrawSettingFlag, int *direct3D, int *half);
 HLL_QUIET_UNIMPLEMENTED(1, bool, DrawDungeon, IsDrawSettingFile, void);
@@ -278,8 +309,8 @@ HLL_QUIET_UNIMPLEMENTED( , void, DrawDungeon, RestartTimer, void);
 	HLL_EXPORT(IsLoading, DrawDungeon_IsLoading), \
 	HLL_EXPORT(IsSucceededLoading, DrawDungeon_IsSucceededLoading), \
 	HLL_TODO_EXPORT(GetLoadingPercent, DrawDungeon_GetLoadingPercent), \
-	HLL_TODO_EXPORT(LoadFromFile, DrawDungeon_LoadFromFile), \
-	HLL_TODO_EXPORT(LoadTexture, DrawDungeon_LoadTexture), \
+	HLL_EXPORT(LoadFromFile, DrawDungeon_LoadFromFile), \
+	HLL_EXPORT(LoadTexture, DrawDungeon_LoadTexture), \
 	HLL_TODO_EXPORT(LoadEventTexture, DrawDungeon_LoadEventTexture), \
 	HLL_EXPORT(GetMapX, DrawDungeon_GetMapX), \
 	HLL_EXPORT(GetMapY, DrawDungeon_GetMapY), \
@@ -468,4 +499,411 @@ HLL_LIBRARY(DrawDungeon14,
 	    HLL_EXPORT(SetLapFilter, DrawDungeon14_SetLapFilter),
 	    HLL_EXPORT(GetDrawMapObjectFlag, DrawDungeon14_GetDrawMapObjectFlag),
 	    HLL_EXPORT(SetDrawMapObjectFlag, DrawDungeon14_SetDrawMapObjectFlag)
+	    );
+
+//bool DrawField_BeginLoad(int nSurface, struct string *szFileName, int nNum);
+//bool DrawField_IsLoadEnd(int nSurface);
+//bool DrawField_StopLoad(int nSurface);
+//float DrawField_GetLoadPercent(int nSurface);
+//bool DrawField_IsLoadSucceeded(int nSurface);
+//bool DrawField_BeginLoadTexture(int nSurface, struct string *szFileName);
+//bool DrawField_IsLoadTextureEnd(int nSurface);
+//bool DrawField_StopLoadTexture(int nSurface);
+//float DrawField_GetLoadTexturePercent(int nSurface);
+//bool DrawField_IsLoadTextureSucceeded(int nSurface);
+//void DrawField_UpdateTexture(int nSurface);
+//bool DrawField_GetDoorNAngle(int nSurface, int nX, int nY, int nZ, float *pfAngle);
+//bool DrawField_GetDoorWAngle(int nSurface, int nX, int nY, int nZ, float *pfAngle);
+//bool DrawField_GetDoorSAngle(int nSurface, int nX, int nY, int nZ, float *pfAngle);
+//bool DrawField_GetDoorEAngle(int nSurface, int nX, int nY, int nZ, float *pfAngle);
+//bool DrawField_SetDoorNAngle(int nSurface, int nX, int nY, int nZ, float fAngle);
+//bool DrawField_SetDoorWAngle(int nSurface, int nX, int nY, int nZ, float fAngle);
+//bool DrawField_SetDoorSAngle(int nSurface, int nX, int nY, int nZ, float fAngle);
+//bool DrawField_SetDoorEAngle(int nSurface, int nX, int nY, int nZ, float fAngle);
+
+CELL_SETTER(DrawField_SetDoorNLock, int, cell->north_door_lock, true);
+CELL_SETTER(DrawField_SetDoorWLock, int, cell->west_door_lock, true);
+CELL_SETTER(DrawField_SetDoorSLock, int, cell->south_door_lock, true);
+CELL_SETTER(DrawField_SetDoorELock, int, cell->east_door_lock, true);
+
+static bool DrawField_GetDoorNLock(int surface, int x, int y, int z, int *lock)
+{
+	struct dgn_cell *cell = dungeon_get_cell(surface, x, y, z);
+	if (!cell || cell->north_door == -1)
+		return false;
+	*lock = cell->north_door_lock;
+	return true;
+}
+
+static bool DrawField_GetDoorWLock(int surface, int x, int y, int z, int *lock)
+{
+	struct dgn_cell *cell = dungeon_get_cell(surface, x, y, z);
+	if (!cell || cell->west_door == -1)
+		return false;
+	*lock = cell->west_door_lock;
+	return true;
+}
+
+static bool DrawField_GetDoorSLock(int surface, int x, int y, int z, int *lock)
+{
+	struct dgn_cell *cell = dungeon_get_cell(surface, x, y, z);
+	if (!cell || cell->south_door == -1)
+		return false;
+	*lock = cell->south_door_lock;
+	return true;
+}
+
+static bool DrawField_GetDoorELock(int surface, int x, int y, int z, int *lock)
+{
+	struct dgn_cell *cell = dungeon_get_cell(surface, x, y, z);
+	if (!cell || cell->east_door == -1)
+		return false;
+	*lock = cell->east_door_lock;
+	return true;
+}
+
+//void DrawField_SetTexStair(int nSurface, int nX, int nY, int nZ, int nTexture, int nType);
+//void DrawField_SetShadowTexFloor(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexCeiling(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexWallN(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexWallW(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexWallS(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexWallE(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexDoorN(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexDoorW(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexDoorS(int nSurface, int nX, int nY, int nZ, int nTexture);
+//void DrawField_SetShadowTexDoorE(int nSurface, int nX, int nY, int nZ, int nTexture);
+
+static void DrawField_CalcShadowMap(int surface)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->dgn)
+		return;
+	return dgn_calc_lightmap(ctx->dgn);
+}
+
+HLL_QUIET_UNIMPLEMENTED(, void, DrawField, SetLooked, int surface, int x, int y, int z, bool flag);
+HLL_WARN_UNIMPLEMENTED(false, bool, DrawField, SetHideDrawMapFloor, int surface, int floor, bool hide);
+//bool DrawField_SetHideDrawMapWall(int nSurface, int nWall, bool bHide);
+
+static void DrawField_SetDrawShadowMap(int surface, bool draw)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->renderer)
+		return;
+	dungeon_renderer_enable_lightmap(ctx->renderer, draw);
+}
+
+static float DrawField_CosDeg(float deg)
+{
+	return cosf(glm_rad(deg));
+}
+
+static float DrawField_SinDeg(float deg)
+{
+	return sinf(glm_rad(deg));
+}
+
+static float DrawField_TanDeg(float deg)
+{
+	return tanf(glm_rad(deg));
+}
+
+static float DrawField_Atan2(float y, float x)
+{
+	return glm_deg(atan2f(y, x));
+}
+
+//bool DrawField_TransPos2DToPos3DOnPlane(int surface, int nScreenX, int nScreenY, float fPlaneY, float *pfX, float *pfY, float *pfZ);
+//bool DrawField_TransPos3DToPos2D(int nSurace, float fX, float fY, float fZ, int *pnScreenX, int *pnScreenY);
+
+static int DrawField_GetCharaNumMax(int surface)
+{
+	return DRAWFIELD_NR_CHARACTERS;
+}
+
+//void DrawField_SetCharaZBias(int surface, float fZBias0, float fZBias1, float fZBias2, float fZBias3);
+
+HLL_QUIET_UNIMPLEMENTED(, void, DrawField, SetCenterOffsetY, int surface, float y);
+//void DrawField_SetBuilBoard(int surface, int num, int sprite);
+
+static void DrawField_SetSphereTheta(int surface, float x, float y, float z)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->dgn)
+		return;
+	ctx->dgn->sphere_theta[0] = x;
+	ctx->dgn->sphere_theta[1] = y;
+	ctx->dgn->sphere_theta[2] = z;
+}
+
+static void DrawField_SetSphereColor(int surface, float top, float bottom)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->dgn)
+		return;
+	ctx->dgn->sphere_color_top = top;
+	ctx->dgn->sphere_color_bottom = bottom;
+}
+
+static bool DrawField_GetSphereTheta(int surface, float *x, float *y, float *z)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->dgn)
+		return false;
+	*x = ctx->dgn->sphere_theta[0];
+	*y = ctx->dgn->sphere_theta[1];
+	*z = ctx->dgn->sphere_theta[2];
+	return true;
+}
+
+static bool DrawField_GetSphereColor(int surface, float *top, float *bottom)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->dgn)
+		return false;
+	*top = ctx->dgn->sphere_color_top;
+	*bottom = ctx->dgn->sphere_color_bottom;
+	return true;
+}
+
+static bool DrawField_GetBackColor(int surface, int *r, int *g, int *b)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->dgn)
+		return false;
+	*r = ctx->dgn->back_color_r;
+	*g = ctx->dgn->back_color_g;
+	*b = ctx->dgn->back_color_b;
+	return true;
+}
+
+static void DrawField_SetBackColor(int surface, int r, int g, int b)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->dgn)
+		return;
+	ctx->dgn->back_color_r = r;
+	ctx->dgn->back_color_g = g;
+	ctx->dgn->back_color_b = b;
+}
+
+//int DrawField_GetPolyObj(int surface, int nX, int nY, int nZ);
+//float DrawField_GetPolyObjMag(int surface, int nX, int nY, int nZ);
+//float DrawField_GetPolyObjRotateH(int surface, int nX, int nY, int nZ);
+//float DrawField_GetPolyObjRotateP(int surface, int nX, int nY, int nZ);
+//float DrawField_GetPolyObjRotateB(int surface, int nX, int nY, int nZ);
+//float DrawField_GetPolyObjOffsetX(int surface, int nX, int nY, int nZ);
+//float DrawField_GetPolyObjOffsetY(int surface, int nX, int nY, int nZ);
+//float DrawField_GetPolyObjOffsetZ(int surface, int nX, int nY, int nZ);
+//void DrawField_SetPolyObj(int surface, int nX, int nY, int nZ, int nPolyObj);
+//void DrawField_SetPolyObjMag(int surface, int nX, int nY, int nZ, float fMag);
+//void DrawField_SetPolyObjRotateH(int surface, int nX, int nY, int nZ, float fRotateH);
+//void DrawField_SetPolyObjRotateP(int surface, int nX, int nY, int nZ, float fRotateP);
+//void DrawField_SetPolyObjRotateB(int surface, int nX, int nY, int nZ, float fRotateB);
+//void DrawField_SetPolyObjOffsetX(int surface, int nX, int nY, int nZ, float fOffsetX);
+//void DrawField_SetPolyObjOffsetY(int surface, int nX, int nY, int nZ, float fOffsetY);
+//void DrawField_SetPolyObjOffsetZ(int surface, int nX, int nY, int nZ, float fOffsetZ);
+
+static void DrawField_SetDrawObjFlag(int surface, int type, bool flag)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->renderer)
+		return;
+	dungeon_renderer_set_draw_obj_flag(ctx->renderer, type, flag);
+}
+
+static bool DrawField_GetDrawObjFlag(int surface, int type)
+{
+	struct dungeon_context *ctx = dungeon_get_context(surface);
+	if (!ctx || !ctx->renderer)
+		return false;
+	return dungeon_renderer_get_draw_obj_flag(ctx->renderer, type);
+}
+
+//int DrawField_GetNumofTexSound(int nSurface, int nType);
+
+HLL_LIBRARY(DrawField,
+	    HLL_EXPORT(Init, DrawField_Init),
+	    HLL_EXPORT(Release, DrawDungeon_Release),
+	    HLL_EXPORT(SetDrawFlag, DrawDungeon_SetDrawFlag),
+	    HLL_EXPORT(GetDrawFlag, DrawDungeon_GetDrawFlag),
+	    HLL_EXPORT(LoadFromFile, DrawDungeon_LoadFromFile),
+	    HLL_EXPORT(LoadTexture, DrawDungeon_LoadTexture),
+	    HLL_TODO_EXPORT(LoadEventTexture, DrawDungeon_LoadEventTexture),
+	    HLL_TODO_EXPORT(BeginLoad, DrawField_BeginLoad),
+	    HLL_TODO_EXPORT(IsLoadEnd, DrawField_IsLoadEnd),
+	    HLL_TODO_EXPORT(StopLoad, DrawField_StopLoad),
+	    HLL_TODO_EXPORT(GetLoadPercent, DrawField_GetLoadPercent),
+	    HLL_TODO_EXPORT(IsLoadSucceeded, DrawField_IsLoadSucceeded),
+	    HLL_TODO_EXPORT(BeginLoadTexture, DrawField_BeginLoadTexture),
+	    HLL_TODO_EXPORT(IsLoadTextureEnd, DrawField_IsLoadTextureEnd),
+	    HLL_TODO_EXPORT(StopLoadTexture, DrawField_StopLoadTexture),
+	    HLL_TODO_EXPORT(GetLoadTexturePercent, DrawField_GetLoadTexturePercent),
+	    HLL_TODO_EXPORT(IsLoadTextureSucceeded, DrawField_IsLoadTextureSucceeded),
+	    HLL_TODO_EXPORT(UpdateTexture, DrawField_UpdateTexture),
+	    HLL_EXPORT(SetCamera, dungeon_set_camera),
+	    HLL_EXPORT(GetMapX, DrawDungeon_GetMapX),
+	    HLL_EXPORT(GetMapY, DrawDungeon_GetMapY),
+	    HLL_EXPORT(GetMapZ, DrawDungeon_GetMapZ),
+	    HLL_EXPORT(IsInMap, DrawDungeon_IsInMap),
+	    HLL_EXPORT(IsFloor, DrawDungeon_IsFloor),
+	    HLL_EXPORT(IsStair, DrawDungeon_IsStair),
+	    HLL_EXPORT(IsStairN, DrawDungeon_IsStairN),
+	    HLL_EXPORT(IsStairW, DrawDungeon_IsStairW),
+	    HLL_EXPORT(IsStairS, DrawDungeon_IsStairS),
+	    HLL_EXPORT(IsStairE, DrawDungeon_IsStairE),
+	    HLL_EXPORT(IsWallN, DrawDungeon_IsWallN),
+	    HLL_EXPORT(IsWallW, DrawDungeon_IsWallW),
+	    HLL_EXPORT(IsWallS, DrawDungeon_IsWallS),
+	    HLL_EXPORT(IsWallE, DrawDungeon_IsWallE),
+	    HLL_EXPORT(IsDoorN, DrawDungeon_IsDoorN),
+	    HLL_EXPORT(IsDoorW, DrawDungeon_IsDoorW),
+	    HLL_EXPORT(IsDoorS, DrawDungeon_IsDoorS),
+	    HLL_EXPORT(IsDoorE, DrawDungeon_IsDoorE),
+	    HLL_EXPORT(IsEnter, DrawDungeon_IsEnter),
+	    HLL_EXPORT(IsEnterN, DrawDungeon_IsEnterN),
+	    HLL_EXPORT(IsEnterW, DrawDungeon_IsEnterW),
+	    HLL_EXPORT(IsEnterS, DrawDungeon_IsEnterS),
+	    HLL_EXPORT(IsEnterE, DrawDungeon_IsEnterE),
+	    HLL_EXPORT(GetEvFloor, DrawDungeon_GetEvFloor),
+	    HLL_EXPORT(GetEvWallN, DrawDungeon_GetEvWallN),
+	    HLL_EXPORT(GetEvWallW, DrawDungeon_GetEvWallW),
+	    HLL_EXPORT(GetEvWallS, DrawDungeon_GetEvWallS),
+	    HLL_EXPORT(GetEvWallE, DrawDungeon_GetEvWallE),
+	    HLL_EXPORT(GetEvFloor2, DrawDungeon_GetEvFloor2),
+	    HLL_EXPORT(GetEvWallN2, DrawDungeon_GetEvWallN2),
+	    HLL_EXPORT(GetEvWallW2, DrawDungeon_GetEvWallW2),
+	    HLL_EXPORT(GetEvWallS2, DrawDungeon_GetEvWallS2),
+	    HLL_EXPORT(GetEvWallE2, DrawDungeon_GetEvWallE2),
+	    HLL_EXPORT(GetTexFloor, DrawDungeon_GetTexFloor),
+	    HLL_EXPORT(GetTexCeiling, DrawDungeon_GetTexCeiling),
+	    HLL_EXPORT(GetTexWallN, DrawDungeon_GetTexWallN),
+	    HLL_EXPORT(GetTexWallW, DrawDungeon_GetTexWallW),
+	    HLL_EXPORT(GetTexWallS, DrawDungeon_GetTexWallS),
+	    HLL_EXPORT(GetTexWallE, DrawDungeon_GetTexWallE),
+	    HLL_EXPORT(GetTexDoorN, DrawDungeon_GetTexDoorN),
+	    HLL_EXPORT(GetTexDoorW, DrawDungeon_GetTexDoorW),
+	    HLL_EXPORT(GetTexDoorS, DrawDungeon_GetTexDoorS),
+	    HLL_EXPORT(GetTexDoorE, DrawDungeon_GetTexDoorE),
+	    HLL_TODO_EXPORT(GetDoorNAngle, DrawField_GetDoorNAngle),
+	    HLL_TODO_EXPORT(GetDoorWAngle, DrawField_GetDoorWAngle),
+	    HLL_TODO_EXPORT(GetDoorSAngle, DrawField_GetDoorSAngle),
+	    HLL_TODO_EXPORT(GetDoorEAngle, DrawField_GetDoorEAngle),
+	    HLL_TODO_EXPORT(SetDoorNAngle, DrawField_SetDoorNAngle),
+	    HLL_TODO_EXPORT(SetDoorWAngle, DrawField_SetDoorWAngle),
+	    HLL_TODO_EXPORT(SetDoorSAngle, DrawField_SetDoorSAngle),
+	    HLL_TODO_EXPORT(SetDoorEAngle, DrawField_SetDoorEAngle),
+	    HLL_EXPORT(SetEvFloor, DrawDungeon_SetEvFloor),
+	    HLL_EXPORT(SetEvWallN, DrawDungeon_SetEvWallN),
+	    HLL_EXPORT(SetEvWallW, DrawDungeon_SetEvWallW),
+	    HLL_EXPORT(SetEvWallS, DrawDungeon_SetEvWallS),
+	    HLL_EXPORT(SetEvWallE, DrawDungeon_SetEvWallE),
+	    HLL_EXPORT(SetEvFloor2, DrawDungeon_SetEvFloor2),
+	    HLL_EXPORT(SetEvWallN2, DrawDungeon_SetEvWallN2),
+	    HLL_EXPORT(SetEvWallW2, DrawDungeon_SetEvWallW2),
+	    HLL_EXPORT(SetEvWallS2, DrawDungeon_SetEvWallS2),
+	    HLL_EXPORT(SetEvWallE2, DrawDungeon_SetEvWallE2),
+	    HLL_TODO_EXPORT(SetEvMag, DrawDungeon_SetEvMag),
+	    HLL_EXPORT(SetEvRate, DrawDungeon_SetEvRate),
+	    HLL_EXPORT(SetEnter, DrawDungeon_SetEnter),
+	    HLL_EXPORT(SetEnterN, DrawDungeon_SetEnterN),
+	    HLL_EXPORT(SetEnterW, DrawDungeon_SetEnterW),
+	    HLL_EXPORT(SetEnterS, DrawDungeon_SetEnterS),
+	    HLL_EXPORT(SetEnterE, DrawDungeon_SetEnterE),
+	    HLL_EXPORT(SetDoorNLock, DrawField_SetDoorNLock),
+	    HLL_EXPORT(SetDoorWLock, DrawField_SetDoorWLock),
+	    HLL_EXPORT(SetDoorSLock, DrawField_SetDoorSLock),
+	    HLL_EXPORT(SetDoorELock, DrawField_SetDoorELock),
+	    HLL_EXPORT(GetDoorNLock, DrawField_GetDoorNLock),
+	    HLL_EXPORT(GetDoorWLock, DrawField_GetDoorWLock),
+	    HLL_EXPORT(GetDoorSLock, DrawField_GetDoorSLock),
+	    HLL_EXPORT(GetDoorELock, DrawField_GetDoorELock),
+	    HLL_EXPORT(SetTexFloor, DrawDungeon_SetTexFloor),
+	    HLL_EXPORT(SetTexCeiling, DrawDungeon_SetTexCeiling),
+	    HLL_EXPORT(SetTexWallN, DrawDungeon_SetTexWallN),
+	    HLL_EXPORT(SetTexWallW, DrawDungeon_SetTexWallW),
+	    HLL_EXPORT(SetTexWallS, DrawDungeon_SetTexWallS),
+	    HLL_EXPORT(SetTexWallE, DrawDungeon_SetTexWallE),
+	    HLL_EXPORT(SetTexDoorN, DrawDungeon_SetTexDoorN),
+	    HLL_EXPORT(SetTexDoorW, DrawDungeon_SetTexDoorW),
+	    HLL_EXPORT(SetTexDoorS, DrawDungeon_SetTexDoorS),
+	    HLL_EXPORT(SetTexDoorE, DrawDungeon_SetTexDoorE),
+	    HLL_TODO_EXPORT(SetTexStair, DrawField_SetTexStair),
+	    HLL_TODO_EXPORT(SetShadowTexFloor, DrawField_SetShadowTexFloor),
+	    HLL_TODO_EXPORT(SetShadowTexCeiling, DrawField_SetShadowTexCeiling),
+	    HLL_TODO_EXPORT(SetShadowTexWallN, DrawField_SetShadowTexWallN),
+	    HLL_TODO_EXPORT(SetShadowTexWallW, DrawField_SetShadowTexWallW),
+	    HLL_TODO_EXPORT(SetShadowTexWallS, DrawField_SetShadowTexWallS),
+	    HLL_TODO_EXPORT(SetShadowTexWallE, DrawField_SetShadowTexWallE),
+	    HLL_TODO_EXPORT(SetShadowTexDoorN, DrawField_SetShadowTexDoorN),
+	    HLL_TODO_EXPORT(SetShadowTexDoorW, DrawField_SetShadowTexDoorW),
+	    HLL_TODO_EXPORT(SetShadowTexDoorS, DrawField_SetShadowTexDoorS),
+	    HLL_TODO_EXPORT(SetShadowTexDoorE, DrawField_SetShadowTexDoorE),
+	    HLL_EXPORT(CalcShadowMap, DrawField_CalcShadowMap),
+	    HLL_EXPORT(DrawMap, dungeon_map_draw),
+	    HLL_EXPORT(SetMapAllViewFlag, dungeon_map_set_all_view),
+	    HLL_EXPORT(SetDrawMapFloor, dungeon_map_set_small_map_floor),
+	    HLL_EXPORT(DrawLMap, dungeon_map_draw_lmap),
+	    HLL_EXPORT(SetMapCG, dungeon_map_set_cg),
+	    HLL_EXPORT(SetDrawLMapFloor, dungeon_map_set_large_map_floor),
+	    HLL_EXPORT(SetPlayerPos, dungeon_set_player_pos),
+	    HLL_EXPORT(SetWalked, dungeon_set_walked),
+	    HLL_EXPORT(SetLooked, DrawField_SetLooked),
+	    HLL_EXPORT(SetHideDrawMapFloor, DrawField_SetHideDrawMapFloor),
+	    HLL_TODO_EXPORT(SetHideDrawMapWall, DrawField_SetHideDrawMapWall),
+	    HLL_EXPORT(SetDrawHalfFlag, DrawDungeon_SetDrawHalfFlag),
+	    HLL_EXPORT(GetDrawHalfFlag, DrawDungeon_GetDrawHalfFlag),
+	    HLL_EXPORT(SetInterlaceMode, DrawDungeon_SetInterlaceMode),
+	    HLL_EXPORT(SetDirect3DMode, DrawDungeon_SetDirect3DMode),
+	    HLL_EXPORT(GetDirect3DMode, DrawDungeon_GetDirect3DMode),
+	    HLL_EXPORT(SaveDrawSettingFlag, DrawDungeon_SaveDrawSettingFlag),
+	    HLL_EXPORT(SetPerspective, dungeon_set_perspective),
+	    HLL_EXPORT(SetDrawShadowMap, DrawField_SetDrawShadowMap),
+	    HLL_TODO_EXPORT(CalcNumofFloor, DrawField_CalcNumofFloor),
+	    HLL_TODO_EXPORT(CalcNumofWalk, DrawField_CalcNumofWalk),
+	    HLL_TODO_EXPORT(CalcNumofWalk2, DrawField_CalcNumofWalk2),
+	    HLL_EXPORT(IsPVSData, DrawDungeon_IsPVSData),
+	    HLL_EXPORT(CosDeg, DrawField_CosDeg),
+	    HLL_EXPORT(SinDeg, DrawField_SinDeg),
+	    HLL_EXPORT(TanDeg, DrawField_TanDeg),
+	    HLL_EXPORT(Sqrt, sqrtf),
+	    HLL_EXPORT(Atan2, DrawField_Atan2),
+	    HLL_TODO_EXPORT(TransPos2DToPos3DOnPlane, DrawField_TransPos2DToPos3DOnPlane),
+	    HLL_TODO_EXPORT(TransPos3DToPos2D, DrawField_TransPos3DToPos2D),
+	    HLL_EXPORT(GetCharaNumMax, DrawField_GetCharaNumMax),
+	    HLL_EXPORT(SetCharaSprite, dungeon_set_chara_sprite),
+	    HLL_EXPORT(SetCharaPos, dungeon_set_chara_pos),
+	    HLL_EXPORT(SetCharaCG, dungeon_set_chara_cg),
+	    HLL_EXPORT(SetCharaCGInfo, dungeon_set_chara_cg_info),
+	    HLL_TODO_EXPORT(SetCharaZBias, DrawField_SetCharaZBias),
+	    HLL_EXPORT(SetCharaShow, dungeon_set_chara_show),
+	    HLL_EXPORT(SetCenterOffsetY, DrawField_SetCenterOffsetY),
+	    HLL_TODO_EXPORT(SetBuilBoard, DrawField_SetBuilBoard),
+	    HLL_EXPORT(SetSphereTheta, DrawField_SetSphereTheta),
+	    HLL_EXPORT(SetSphereColor, DrawField_SetSphereColor),
+	    HLL_EXPORT(GetSphereTheta, DrawField_GetSphereTheta),
+	    HLL_EXPORT(GetSphereColor, DrawField_GetSphereColor),
+	    HLL_EXPORT(GetBackColor, DrawField_GetBackColor),
+	    HLL_EXPORT(SetBackColor, DrawField_SetBackColor),
+	    HLL_TODO_EXPORT(GetPolyObj, DrawField_GetPolyObj),
+	    HLL_TODO_EXPORT(GetPolyObjMag, DrawField_GetPolyObjMag),
+	    HLL_TODO_EXPORT(GetPolyObjRotateH, DrawField_GetPolyObjRotateH),
+	    HLL_TODO_EXPORT(GetPolyObjRotateP, DrawField_GetPolyObjRotateP),
+	    HLL_TODO_EXPORT(GetPolyObjRotateB, DrawField_GetPolyObjRotateB),
+	    HLL_TODO_EXPORT(GetPolyObjOffsetX, DrawField_GetPolyObjOffsetX),
+	    HLL_TODO_EXPORT(GetPolyObjOffsetY, DrawField_GetPolyObjOffsetY),
+	    HLL_TODO_EXPORT(GetPolyObjOffsetZ, DrawField_GetPolyObjOffsetZ),
+	    HLL_TODO_EXPORT(SetPolyObj, DrawField_SetPolyObj),
+	    HLL_TODO_EXPORT(SetPolyObjMag, DrawField_SetPolyObjMag),
+	    HLL_TODO_EXPORT(SetPolyObjRotateH, DrawField_SetPolyObjRotateH),
+	    HLL_TODO_EXPORT(SetPolyObjRotateP, DrawField_SetPolyObjRotateP),
+	    HLL_TODO_EXPORT(SetPolyObjRotateB, DrawField_SetPolyObjRotateB),
+	    HLL_TODO_EXPORT(SetPolyObjOffsetX, DrawField_SetPolyObjOffsetX),
+	    HLL_TODO_EXPORT(SetPolyObjOffsetY, DrawField_SetPolyObjOffsetY),
+	    HLL_TODO_EXPORT(SetPolyObjOffsetZ, DrawField_SetPolyObjOffsetZ),
+	    HLL_EXPORT(SetDrawObjFlag, DrawField_SetDrawObjFlag),
+	    HLL_EXPORT(GetDrawObjFlag, DrawField_GetDrawObjFlag),
+	    HLL_EXPORT(GetTexSound, DrawDungeon_GetTexSound),
+	    HLL_TODO_EXPORT(GetNumofTexSound, DrawField_GetNumofTexSound)
 	    );


### PR DESCRIPTION
DrawField is a variant of DrawDungeon. Unlike the first-person perspective of DrawDungeon, DrawField uses a third-person, bird's-eye view camera.

Key features include:

- Character Rendering: A new system to render up to 256 billboarded sprites (characters, enemies, etc.) in the 3D world. The renderer supports controlling position, sprite animation, and visibility for each character.

- DrawField HLL API: Functions for loading assets, managing characters, and manipulating dungeon properties like door locks.

- Renderer: The core renderer is updated to support the DrawField mode. This includes disabling fog, handling sprite sheets via UV manipulation, and rendering ceilings as billboards.

- Map: The 2D map has been updated to reflect the DrawField style, including colored door lock indicators.