### PR TITLE
Revert "fix: Y origin in prepare_chipmunk_shader"

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -109,9 +109,8 @@ static void prepare_chipmunk_shader(struct gfx_render_job *job, void *data)
 		r = (Rectangle) { 0, 0, sp->rect.w, sp->rect.h };
 	}
 
-	int sy_bottom = sp->rect.h - (r.y + r.h);
-	glUniform2f(s->bot_left,  r.x, sy_bottom);
-	glUniform2f(s->top_right, r.x + r.w, sy_bottom + r.h);
+	glUniform2f(s->bot_left, r.x, r.y);
+	glUniform2f(s->top_right, r.x + r.w, r.y + r.h);
 }
 
 void sprite_init_sact(void)


### PR DESCRIPTION
Reverts nunuhara/xsystem4#267

This was not correct it broke the scrollbar's y rendering position. I will see if I find a better solution.