### PR TITLE
fix: anchor sprite surface_area at sprite origin

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -169,9 +169,15 @@ static void sprite_render(struct sprite *_sp)
 		break;
 	}
 
-	_gfx_render_texture(&sprite_shader.s, &sp->texture, &sp->rect, sp);
+	Rectangle r = sp->rect;
+	if (sp->surface_area.x || sp->surface_area.y) {
+		r.x -= sp->surface_area.x;
+		r.y -= sp->surface_area.y;
+	}
+
+	_gfx_render_texture(&sprite_shader.s, &sp->texture, &r, sp);
 	if (sp->text.texture.handle) {
-		_gfx_render_texture(&sprite_shader.s, &sp->text.texture, &sp->rect, sp);
+		_gfx_render_texture(&sprite_shader.s, &sp->text.texture, &r, sp);
 	}
 
 	if (sp->draw_method != DRAW_METHOD_NORMAL)


### PR DESCRIPTION
## Summary
This fixes the Magnum Gauge (Rance Quest Magnum), similar to #269 but via a different approach. We now anchor the region selected by `surface_area(x,y,w,h)` back to the sprite origin (top-left). If the mask’s `x` or `y` is non-zero, we offset the draw rect so the masked region still appears at the sprite origin.

## Current situation with the Magnum Gauge
The gauge’s sprite rect starts below its container. As it fills, rect.y decreases (moving upward) and `surface_area` grows. However, the mask spans the bottom of the sprite and grows upward, while the game expects the sprite origin to come into view. Result: the visible area appears displaced

## The Fix
Before rendering a sprite we should check if it has a surface area and whether the x or y is not zero. If so we need to adjust the position we pass into the texture renderer so that the sprite still drawn at the sprite origin.

## Testing
The magnum gauge now works correctly, and all the scroll bars are unaffected.