### PR TITLE
ffi: Make HLL calls safe against heap reallocation

### DIFF
--- a/include/vm/heap.h
+++ b/include/vm/heap.h
@@ -78,15 +78,6 @@ int32_t heap_alloc_string(struct string *s);
 
 void heap_describe_slot(int slot);
 
-/*
- * Guarantee `headroom` free slots are available on the heap.
- *
- * XXX: this is a hack to fix an issue with HLL calls where a pointer into the
- *      heap can be made invalid by a heap reallocation triggered within the
- *      body of the HLL function.
- */
-void heap_guarantee(unsigned headroom);
-
 #ifdef VM_PRIVATE
 
 extern uint32_t heap_next_seq;

--- a/src/heap.c
+++ b/src/heap.c
@@ -60,19 +60,6 @@ void heap_grow(size_t new_size)
 	heap_size = new_size;
 }
 
-void heap_guarantee(unsigned headroom)
-{
-	if (heap_size - heap_free_ptr >= headroom)
-		return;
-
-	size_t new_size = heap_size;
-	while (new_size - heap_free_ptr < headroom) {
-		new_size += HEAP_ALLOC_STEP;
-	}
-
-	heap_grow(new_size);
-}
-
 void heap_init(void)
 {
 	if (!heap) {


### PR DESCRIPTION
In hll_call(), pointers to heap data passed by reference could become invalid if the heap was reallocated during the call.

The previous implementation attempted to prevent this by calling heap_guarantee() to pre-allocate heap space. However, this approach does not work for certain functions in PastelChime2 HLL, which can perform an unbounded number of heap allocations.

This commit removes heap_guarantee() and replaces it with a more robust copy-in/copy-out strategy:

- Before the call (Copy-in): For reference arguments, the pointer value is copied from the heap to a local variable on the stack. A pointer to this local variable is then passed to the HLL function.
- After the call (Copy-out): The pointer value, which may have been modified by the HLL function, is written back from the local variable to its original slot in the heap.