### PR TITLE
Pastel Chime Continue: Make sure resume save v7 is used

### DIFF
--- a/src/resume.c
+++ b/src/resume.c
@@ -969,6 +969,11 @@ static int write_rsave_image_comments(const char *key, const char *path, struct 
 		return 0;
 	}
 
+	// Comments were added in RSM v7, so if the save is older, upgrade it.
+	if (save->version <= 6) {
+		save->version = 7;
+	}
+
 	for (int i = 0; i < save->nr_comments; i++) {
 		free(save->comments[i]);
 	}


### PR DESCRIPTION
Because `make_rsave()` determines the version of resume save based on the AIN version, it returns RSM v6 for Pastel Chime Continue. But this game requires the comment field added in RSM v7.

This solves the issue by upgrading to RSM v7 when comments are written to the save file.