### PR TITLE
Android: Do not use SDL_WINDOW_FULLSCREEN

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -608,6 +608,9 @@ void handle_events(void)
 		case SDL_WINDOWEVENT:
 			handle_window_event(&e);
 			break;
+		case SDL_APP_DIDENTERFOREGROUND:
+			gfx_swap();
+			break;
 		case SDL_KEYDOWN:
 			if (e.key.keysym.scancode == SDL_SCANCODE_F9)
 				vm_stack_trace();

--- a/src/video.c
+++ b/src/video.c
@@ -243,19 +243,12 @@ int gfx_init(void)
 #endif
 
 	sdl.format = SDL_AllocFormat(SDL_PIXELFORMAT_RGBA32);
-	uint32_t window_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN;
-#ifdef __ANDROID__
-	window_flags |= SDL_WINDOW_FULLSCREEN;
-	SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
-#else
-	window_flags |= SDL_WINDOW_RESIZABLE;
-#endif
 	sdl.window =  SDL_CreateWindow("XSystem4",
 				       SDL_WINDOWPOS_UNDEFINED,
 				       SDL_WINDOWPOS_UNDEFINED,
 				       config.view_width,
 				       config.view_height,
-				       window_flags);
+				       SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
 	if (!sdl.window)
 		ERROR("SDL_CreateWindow failed: %s", SDL_GetError());
 


### PR DESCRIPTION
This is part of the fix for https://github.com/kichikuou/xsystem4-android/issues/24.