### PR TITLE
Fix build error when debugger is disabled

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -24,6 +24,7 @@
 #include "input.h"
 #include "scene.h"
 #include "vm.h"
+#include "xsystem4.h"
 #include "debugger.h"
 
 #ifndef M_PI


### PR DESCRIPTION
This fixes "call to undeclared function 'screenshot_save'" error when xsystem4.h is not included by debugger.h.