### PR TITLE
parts: Fix ERROR() in flash.c

### DIFF
--- a/src/parts/flash.c
+++ b/src/parts/flash.c
@@ -304,8 +304,6 @@ static void define_sprite(struct parts_flash *f, struct swf_tag_define_sprite *t
 			ERROR("unsupported tag %d in sprite", t->type);
 		}
 	}
-	if (!obj)
-		ERROR("sprite has no PlaceObject2 tag");
 	slot->value = obj;
 }
 

--- a/src/parts/render.c
+++ b/src/parts/render.c
@@ -171,8 +171,8 @@ static void parts_render_flash_shape(struct parts *parts, struct parts_flash *f,
 static void parts_render_flash_sprite(struct parts *parts, struct parts_flash *f, struct parts_flash_object *obj, struct swf_tag_define_sprite *tag)
 {
 	struct parts_flash_object *obj2 = ht_get_int(f->sprites, tag->sprite_id, NULL);
-	if (!obj)
-		ERROR("undefined sprite id %d", tag->sprite_id);
+	if (!obj2)
+		return;  // sprite has no visual elements.
 
 	struct swf_tag *child = ht_get_int(f->dictionary, obj2->character_id, NULL);
 	if (!child)


### PR DESCRIPTION
This fixes a crash when processing DefineSprite tags that contain no PlaceObject2 tags, as seen in Rance Quest's `Battle/斧攻撃・雷.aff`. These sprites are now registered in parts_flash->sprites with a NULL object, and are safely skipped by the renderer.