### PR TITLE
SystemService: fullscreen control

### DIFF
--- a/include/gfx/gfx.h
+++ b/include/gfx/gfx.h
@@ -77,6 +77,9 @@ void gfx_fini(void);
 
 Texture *gfx_main_surface(void);
 void gfx_set_window_logical_size(int w, int h);
+bool gfx_set_fullscreen(bool enable);
+bool gfx_is_fullscreen(void);
+void gfx_toggle_fullscreen(void);
 void gfx_update_screen_scale(void);
 void gfx_set_wait_vsync(bool wait);
 float gfx_get_frame_rate(void);

--- a/src/hll/SystemService.c
+++ b/src/hll/SystemService.c
@@ -69,11 +69,19 @@ HLL_WARN_UNIMPLEMENTED(false, bool, SystemService, AddURLMenu, struct string *ti
 
 static bool SystemService_IsFullScreen(void)
 {
-	return false;
+	return gfx_is_fullscreen();
 }
 
-//bool SystemService_ChangeNormalScreen(void);
-HLL_WARN_UNIMPLEMENTED(false, bool, SystemService, ChangeFullScreen);
+static bool SystemService_ChangeNormalScreen(void)
+{
+	return gfx_set_fullscreen(false);
+}
+
+static bool SystemService_ChangeFullScreen(void)
+{
+	return gfx_set_fullscreen(true);
+}
+
 HLL_WARN_UNIMPLEMENTED(false, bool, SystemService, InitMainWindowPosAndSize);
 
 //static bool SystemService_UpdateView(void);
@@ -408,7 +416,7 @@ HLL_LIBRARY(SystemService,
 	    HLL_EXPORT(GetGameName, SystemService_GetGameName),
 	    HLL_EXPORT(AddURLMenu, SystemService_AddURLMenu),
 	    HLL_EXPORT(IsFullScreen, SystemService_IsFullScreen),
-	    HLL_TODO_EXPORT(ChangeNormalScreen, SystemService_ChangeNormalScreen),
+	    HLL_EXPORT(ChangeNormalScreen, SystemService_ChangeNormalScreen),
 	    HLL_EXPORT(ChangeFullScreen, SystemService_ChangeFullScreen),
 	    HLL_EXPORT(InitMainWindowPosAndSize, SystemService_InitMainWindowPosAndSize),
 	    HLL_EXPORT(UpdateView, SystemService_UpdateView),

--- a/src/input.c
+++ b/src/input.c
@@ -616,9 +616,7 @@ void handle_events(void)
 			if (e.key.keysym.scancode == SDL_SCANCODE_F9) {
 				vm_stack_trace();
 			} else if (e.key.keysym.scancode == SDL_SCANCODE_F11) {
-				uint32_t flag = SDL_WINDOW_FULLSCREEN_DESKTOP;
-				bool fs = SDL_GetWindowFlags(sdl.window) & flag;
-				SDL_SetWindowFullscreen(sdl.window, fs ? 0 : flag);
+				gfx_toggle_fullscreen();
 			} else if (e.key.keysym.scancode == SDL_SCANCODE_S) {
 				if (e.key.keysym.mod & (KMOD_LALT | KMOD_RALT)) {
 					screenshot_save();

--- a/src/video.c
+++ b/src/video.c
@@ -319,6 +319,26 @@ void gfx_set_window_logical_size(int w, int h)
 	main_surface_init(w, h);
 }
 
+bool gfx_set_fullscreen(bool enable)
+{
+	uint32_t flags = enable ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0;
+	if (SDL_SetWindowFullscreen(sdl.window, flags) < 0) {
+		WARNING("Failed to set fullscreen mode: %s", SDL_GetError());
+		return false;
+	}
+	return true;
+}
+
+bool gfx_is_fullscreen(void)
+{
+	return SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_FULLSCREEN_DESKTOP;
+}
+
+void gfx_toggle_fullscreen(void)
+{
+	gfx_set_fullscreen(!gfx_is_fullscreen());
+}
+
 void gfx_update_screen_scale(void)
 {
 	int display_w, display_h;


### PR DESCRIPTION
This makes the fullscreen option in the in-game config work for games that use it (e.g. Rance 01, Rance Quest). By implementing the necessary functions in SystemService. You can still toggle fullscreen with F11