### PR TITLE
PartsEngine: Fix state stuck at CLICKED when target state is uninitialized

### DIFF
--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -881,7 +881,9 @@ bool parts_numeral_set_number(struct parts *parts, struct parts_numeral *num, in
 
 void parts_set_state(struct parts *parts, enum parts_state_type state)
 {
-	if (parts->state != state && parts->states[state].type != PARTS_UNINITIALIZED) {
+	while (state > PARTS_STATE_DEFAULT && parts->states[state].type == PARTS_UNINITIALIZED)
+		state--;
+	if (parts->state != state) {
 		parts->state = state;
 		parts_dirty(parts);
 	}


### PR DESCRIPTION
`parts_set_state()` silently ignored transitions to uninitialized states, causing parts without a HOVERED state to remain in CLICKED after mouse release. Fall back through CLICKED -> HOVERED -> DEFAULT so the first initialized state is always selected. DEFAULT is accepted unconditionally as the terminal fallback, matching the original engine's behavior.