### PR TITLE
PartsEngine: Implement PE_SetPartsRectangleDetectionSize

### DIFF
--- a/src/parts/debug.c
+++ b/src/parts/debug.c
@@ -270,6 +270,8 @@ static cJSON *parts_state_to_json(struct parts_state *state, bool verbose)
 	case PARTS_MOVIE:
 		parts_movie_to_json(&state->movie, obj, verbose);
 		break;
+	case PARTS_RECT_DETECTION:
+		break;
 	}
 
 	return obj;
@@ -557,6 +559,9 @@ static void parts_list_print(struct parts *parts, int indent)
 		break;
 	case PARTS_MOVIE:
 		sys_message("(movie sp=%d)", state->movie.sprite_no);
+		break;
+	case PARTS_RECT_DETECTION:
+		sys_message("(rect_detection)");
 		break;
 	}
 

--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -212,6 +212,8 @@ static void parts_state_free(struct parts_state *state)
 		if (state->movie.sprite_no >= 0)
 			sact_SP_Delete(state->movie.sprite_no);
 		break;
+	case PARTS_RECT_DETECTION:
+		break;
 	}
 	memset(state, 0, sizeof(struct parts_state));
 }
@@ -258,6 +260,7 @@ void parts_state_reset(struct parts_state *state, enum parts_type type)
 	case PARTS_ANIMATION:
 	case PARTS_FLASH:
 	case PARTS_FLAT:
+	case PARTS_RECT_DETECTION:
 		break;
 	case PARTS_MOVIE:
 		state->movie.sprite_no = -1;
@@ -1919,6 +1922,7 @@ void PE_SetComponentType(int parts_no, int type, int state)
 	case 14: pt = PARTS_HGAUGE; break;
 	case 15: pt = PARTS_VGAUGE; break;
 	case 16: pt = PARTS_NUMERAL; break;
+	case 17: pt = PARTS_RECT_DETECTION; break;
 	case 18: pt = PARTS_CONSTRUCTION_PROCESS; break;
 	case 20: pt = PARTS_FLAT; break;
 	case 22: pt = PARTS_MOVIE; break;
@@ -1946,6 +1950,7 @@ int PE_GetComponentType(int parts_no, int state)
 	case PARTS_HGAUGE: return 14;
 	case PARTS_VGAUGE: return 15;
 	case PARTS_NUMERAL: return 16;
+	case PARTS_RECT_DETECTION: return 17;
 	case PARTS_CONSTRUCTION_PROCESS: return 18;
 	case PARTS_FLAT: return 20;
 	case PARTS_MOVIE: return 22;
@@ -1957,8 +1962,15 @@ int PE_GetComponentType(int parts_no, int state)
 
 bool PE_SetPartsRectangleDetectionSize(int parts_no, int w, int h, int state)
 {
-	UNIMPLEMENTED("(%d, %d, %d, %d)", parts_no, w, h, state);
-	return false;
+	if (!parts_state_valid(--state))
+		return false;
+	struct parts *parts = parts_try_get(parts_no);
+	if (!parts)
+		return false;
+	if (parts->states[state].type != PARTS_RECT_DETECTION)
+		parts_state_reset(&parts->states[state], PARTS_RECT_DETECTION);
+	parts_set_dims(parts, &parts->states[state].common, w, h);
+	return true;
 }
 
 bool PE_SetPartsCGDetectionSize(int parts_no, struct string *cg_name, int state)

--- a/src/parts/parts_internal.h
+++ b/src/parts/parts_internal.h
@@ -105,7 +105,8 @@ enum parts_type {
 	PARTS_FLASH,
 	PARTS_FLAT,
 	PARTS_MOVIE,
-#define PARTS_NR_TYPES (PARTS_MOVIE+1)
+	PARTS_RECT_DETECTION,
+#define PARTS_NR_TYPES (PARTS_RECT_DETECTION+1)
 };
 
 struct parts_common {

--- a/src/parts/render.c
+++ b/src/parts/render.c
@@ -431,6 +431,8 @@ void parts_render(struct parts *parts)
 	case PARTS_FLAT:
 		parts_render_flat(parts, &state->flat);
 		break;
+	case PARTS_RECT_DETECTION:
+		break;
 	}
 }
 

--- a/src/parts/save.c
+++ b/src/parts/save.c
@@ -387,6 +387,7 @@ static void save_parts_state(struct iarray_writer *w, struct parts_state *state)
 		save_parts_flat(w, &state->flat);
 		break;
 	case PARTS_MOVIE:
+	case PARTS_RECT_DETECTION:
 		break;
 	}
 }
@@ -431,6 +432,7 @@ static void load_parts_state(struct iarray_reader *r, struct parts *parts,
 		load_parts_flat(r, parts, &state->flat);
 		break;
 	case PARTS_MOVIE:
+	case PARTS_RECT_DETECTION:
 		break;
 	}
 }


### PR DESCRIPTION
This sets the hitbox size for rectangle-based hit detection, as a new parts type PARTS_RECT_DETECTION. This is a detection-only type with no drawing.