### PR TITLE
3d: Fix camera yaw direction and rotation order

### DIFF
--- a/src/3d/reign.c
+++ b/src/3d/reign.c
@@ -752,7 +752,7 @@ bool RE_plugin_get_camera_z_vector(struct RE_plugin *plugin, vec3 out)
 		glm_rad(plugin->camera.roll)
 	};
 	mat4 rot;
-	glm_euler(euler, rot);
+	glm_euler_yxz(euler, rot);
 	glm_mat4_mulv3(rot, GLM_FORWARD, 0.f, out);
 	return true;
 }

--- a/src/3d/renderer.c
+++ b/src/3d/renderer.c
@@ -337,7 +337,7 @@ void RE_calc_view_matrix(struct RE_camera *camera, vec3 up, mat4 out)
 		glm_rad(camera->roll)
 	};
 	mat4 rot;
-	glm_euler(euler, rot);
+	glm_euler_yxz(euler, rot);
 	glm_mat4_mulv3(rot, front, 0.0, front);
 	glm_look(camera->pos, front, up, out);
 }

--- a/src/hll/ReignEngine.c
+++ b/src/hll/ReignEngine.c
@@ -1082,7 +1082,7 @@ static bool ReignEngine_SetCameraAngle(int plugin, float angle)
 	struct RE_plugin *p = get_plugin(plugin);
 	if (!p)
 		return false;
-	p->camera.yaw = -angle;
+	p->camera.yaw = angle;
 	return true;
 }
 


### PR DESCRIPTION
The camera view direction was computed incorrectly in two ways:

1. `glm_euler` (XYZ order) applies pitch around world X. The original engine uses YXZ where pitch is around the camera's local X after yaw.

2. `SetCameraAngle` negated the input yaw.