### PR TITLE
PartsEngine: clamp passed_time to 0 in PE_UpdateComponent

### DIFF
--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -1166,7 +1166,7 @@ void PE_Update(int passed_time, bool message_window_show)
 	audio_update();
 	parts_update_animation(passed_time);
 	PE_UpdateInputState(passed_time);
-	parts_render_update(passed_time);
+	parts_render_update();
 }
 
 void PE_UpdateParts(int passed_time, possibly_unused bool is_skip, bool message_window_show)
@@ -1174,7 +1174,7 @@ void PE_UpdateParts(int passed_time, possibly_unused bool is_skip, bool message_
 	parts_message_window_show = message_window_show;
 	audio_update();
 	parts_update_animation(passed_time);
-	parts_render_update(passed_time);
+	parts_render_update();
 }
 
 void PE_SetDelegateIndex(int parts_no, int delegate_index)

--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -1120,6 +1120,11 @@ static void parts_update_component(struct parts *parts)
 
 void PE_UpdateComponent(possibly_unused int passed_time)
 {
+	// After loading a save, the game script may compute a negative time delta
+	// because it stores an absolute system.GetTime() value in the save data,
+	// which is meaningless across process restarts.
+	if (passed_time < 0)
+		passed_time = 0;
 	while (!TAILQ_EMPTY(&dirty_list)) {
 		// pop parts object from dirty list
 		struct parts *parts = TAILQ_FIRST(&dirty_list);

--- a/src/parts/parts_internal.h
+++ b/src/parts/parts_internal.h
@@ -512,7 +512,7 @@ struct string *parts_text_get(struct parts_text *t);
 
 // render.c
 void parts_render_init(void);
-void parts_render_update(int passed_time);
+void parts_render_update(void);
 void parts_engine_dirty(void);
 void parts_engine_clean(void);
 void parts_dirty(struct parts *parts);

--- a/src/parts/render.c
+++ b/src/parts/render.c
@@ -632,7 +632,7 @@ void parts_sprite_render(struct sprite *sp)
 
 static bool pe_dirty = false;
 
-void parts_render_update(int passed_time)
+void parts_render_update(void)
 {
 	if (pe_dirty) {
 		struct parts *p;

--- a/src/parts/render.c
+++ b/src/parts/render.c
@@ -634,12 +634,6 @@ static bool pe_dirty = false;
 
 void parts_render_update(int passed_time)
 {
-	// XXX: hack for Rance 01 load issue
-	//      There is a bug in Rance 01 where a single bad frame is displayed after
-	//      loading a save. When this happens, the game passes a negative time delta
-	//      to PE_Update. We fix this issue by ignoring such calls.
-	if (passed_time < 0)
-		return;
 	if (pe_dirty) {
 		struct parts *p;
 		PARTS_LIST_FOREACH(p) {


### PR DESCRIPTION
After loading a save, the game script may give a negative `passed_time` because it computes the delta time using an absolute `system.GetTime()` value stored in the save data.

This fixes hang on load in Rance 9.

This also removes the equivalent workaround in `parts_render_update` for Rance 01, since the new clamp covers that case as well.