### PR TITLE
parts: impl sprite_deform for SetPartsCG

### DIFF
--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -1188,12 +1188,13 @@ int PE_GetDelegateIndex(int parts_no)
 	return parts ? parts->delegate_index : -1;
 }
 
-bool PE_SetPartsCG(int parts_no, struct string *cg_name, possibly_unused int sprite_deform, int state)
+bool PE_SetPartsCG(int parts_no, struct string *cg_name, int sprite_deform, int state)
 {
 	if (!parts_state_valid(--state))
 		return false;
 
 	struct parts *parts = parts_get(parts_no);
+	parts->sprite_deform = sprite_deform;
 	if (!cg_name || *(cg_name->text) == '\0') {
 		parts_state_reset(&parts->states[state], PARTS_CG);
 		parts_dirty(parts);
@@ -1204,12 +1205,13 @@ bool PE_SetPartsCG(int parts_no, struct string *cg_name, possibly_unused int spr
 	return parts_cg_set(parts, cg, cg_name);
 }
 
-bool PE_SetPartsCG_by_index(int parts_no, int cg_no, possibly_unused int sprite_deform, int state)
+bool PE_SetPartsCG_by_index(int parts_no, int cg_no, int sprite_deform, int state)
 {
 	if (!parts_state_valid(--state))
 		return false;
 
 	struct parts *parts = parts_get(parts_no);
+	parts->sprite_deform = sprite_deform;
 	if (!cg_no) {
 		parts_state_reset(&parts->states[state], PARTS_CG);
 		parts_dirty(parts);

--- a/src/parts/parts.c
+++ b/src/parts/parts.c
@@ -1224,12 +1224,13 @@ bool PE_SetPartsCG_by_index(int parts_no, int cg_no, int sprite_deform, int stat
 
 // XXX: Rance Quest
 bool PE_SetPartsCG_by_string_index(int parts_no, struct string *cg_name,
-		possibly_unused int sprite_deform, int state)
+		int sprite_deform, int state)
 {
 	if (!parts_state_valid(--state))
 		return false;
 
 	struct parts *parts = parts_get(parts_no);
+	parts->sprite_deform = sprite_deform;
 	if (!cg_name) {
 		parts_state_reset(&parts->states[state], PARTS_CG);
 		parts_dirty(parts);

--- a/src/parts/render.c
+++ b/src/parts/render.c
@@ -153,7 +153,25 @@ static void parts_render_cg(struct parts *parts, struct parts_common *common)
 	glm_rotate_z(mw_transform, glm_rad(parts->local.rotation.z), mw_transform);
 	glm_scale(mw_transform, (vec3){ parts->global.scale.x, parts->global.scale.y, 1.0 });
 	glm_translate(mw_transform, (vec3){ common->origin_offset.x, common->origin_offset.y, 0 });
-	glm_scale(mw_transform, (vec3){ common->w, common->h, 1.0 });
+
+	switch (parts->sprite_deform) {
+	// Flip horizontally
+	case 1:
+		glm_translate(mw_transform, (vec3){ common->w, 0.0f, 0.0f });
+		glm_scale(mw_transform, (vec3){ -common->w, common->h, 1.0f });
+		break;
+	// Flip vertically
+	case 2:
+		glm_translate(mw_transform, (vec3){ 0.0f, common->h, 0.0f });
+		glm_scale(mw_transform, (vec3){ common->w, -common->h, 1.0f });
+		break;
+	default:
+		WARNING("Invalid sprite_deform: %d", parts->sprite_deform);
+	// No deform
+	case 0:
+		glm_scale(mw_transform, (vec3){ common->w, common->h, 1.0 });
+		break;
+	}
 
 	Rectangle r = common->surface_area;
 	if (!r.w && !r.h) {


### PR DESCRIPTION
Implement SpriteDeform handling for Parts_SetPartsCG

0: No flip
1: Flip horizontally
2: Flip vertically

Usage of this feature can be observed in Rance 9 where the CG is flipped horizontally when the speaker is on the right hand side of the screen.