### PR TITLE
3de: Add support for billboard and polygon objects

### DIFF
--- a/shaders/reign.f.glsl
+++ b/shaders/reign.f.glsl
@@ -92,6 +92,9 @@ uniform int diffuse_type;
 uniform float shadow_darkness;
 uniform float shadow_bias;
 uniform int alpha_mode;
+#if ENGINE == SEAL_ENGINE
+uniform vec3 color_add;
+#endif
 
 in vec2 tex_coord;
 in vec2 light_tex_coord;
@@ -137,6 +140,10 @@ void main() {
 			frag_rgb += texel.rgb * diffuse * color_mod.rgb * diffuse_mod;
 		}
 	}
+
+#if ENGINE == SEAL_ENGINE
+	frag_rgb += color_add;
+#endif
 
 #if ENGINE == REIGN_ENGINE
 	// Specular lighting

--- a/src/3d/3d_internal.h
+++ b/src/3d/3d_internal.h
@@ -191,6 +191,7 @@ struct RE_renderer {
 	GLint uv_scroll;
 	GLint blend_tex;
 	GLint use_blend_texture;
+	GLint color_add;
 
 	GLuint billboard_vao;
 	GLuint billboard_attr_buffer;
@@ -557,13 +558,43 @@ struct s3de {
 	int loop_end_frame;
 	struct s3de_object *objects;
 	int nr_objects;
+	struct hash_table *textures; // name -> struct billboard_texture*
 };
 
 struct s3de *s3de_load(struct archive *aar, const char *path);
 void s3de_free(struct s3de *s);
 
+struct s3de_particle {
+	float begin_frame, end_frame;
+	vec3 world_pos;       // spawn-time world position
+	vec3 spawn_offset;    // offset from emitter pos
+	vec3 direction;
+	vec3 spawn_dir;       // emitter motion direction at spawn frame
+	float speed, accel;
+	float movement_distance, movement_curve;
+	float start_size_scale, end_size_scale;
+	float start_x_scale, end_x_scale;
+	float start_y_scale, end_y_scale;
+	float offset_x, offset_y;  // per-particle 2D quad pivot shift
+	vec3 start_rotation_deg, end_rotation_deg;
+	float fade_in_frames, fade_out_frames;
+};
+
+// Emitter-level values interpolated once per frame by s3de_effect_update,
+// then read (and combined with per-particle values) during rendering.
+struct s3de_object_state {
+	vec3 emitter_pos;
+	float emitter_size, emitter_x_size, emitter_y_size;
+	float emitter_alpha;
+	vec3 emitter_rotation_deg;
+	vec3 multiply_color;
+	vec3 additive_color;
+	struct s3de_particle *particles;  // length = obj->particle_count
+};
+
 struct s3de_effect {
 	struct s3de *s3de;
+	struct s3de_object_state *objects;  // length = s3de->nr_objects
 	int wav_channel;       // -1 if no sound
 	bool sound_started;
 	float last_frame;
@@ -573,6 +604,16 @@ struct s3de_effect *s3de_effect_create(struct s3de *s, struct archive *aar);
 void s3de_effect_free(struct s3de_effect *eff);
 void s3de_effect_update(struct RE_instance *inst);
 void s3de_calc_frame_range(struct s3de *s, struct motion *motion);
+bool s3de_particle_alpha(struct s3de_object_state *st, struct s3de_particle *p,
+	float frame, float *alpha_out);
+bool s3de_billboard_world_transform(struct RE_instance *inst,
+	struct s3de_object *obj, struct s3de_object_state *st,
+	struct s3de_particle *p, float frame, mat3 camera_rot,
+	mat4 out);
+bool s3de_mesh_world_transform(struct RE_instance *inst,
+	struct s3de_object *obj, struct s3de_object_state *st,
+	struct s3de_particle *p, float frame, mat3 camera_rot, vec3 camera_pos,
+	mat4 out);
 
 // parser.c
 

--- a/src/3d/renderer.c
+++ b/src/3d/renderer.c
@@ -264,6 +264,7 @@ struct RE_renderer *RE_renderer_new(void)
 	r->uv_scroll = glGetUniformLocation(r->program, "uv_scroll");
 	r->blend_tex = glGetUniformLocation(r->program, "blend_tex");
 	r->use_blend_texture = glGetUniformLocation(r->program, "use_blend_texture");
+	r->color_add = glGetUniformLocation(r->program, "color_add");
 
 	glGenRenderbuffers(1, &r->depth_buffer);
 
@@ -689,6 +690,210 @@ static void render_polygon_particles(struct RE_renderer *r, struct RE_instance *
 	}
 }
 
+static void render_s3de_billboard_particles(struct RE_renderer *r, struct RE_instance *inst,
+					    struct s3de_object *obj, struct s3de_object_state *st,
+					    mat3 camera_rot, float frame)
+{
+	if (!obj->texture || obj->particle_count == 0)
+		return;
+
+	struct billboard_texture *bt = ht_get(
+		inst->s3de_effect->s3de->textures, obj->texture, NULL);
+	if (!bt)
+		return;
+
+	glUniform1i(r->diffuse_type, DIFFUSE_EMISSIVE);
+	switch (obj->blend_type) {
+	case S3DE_BLEND_NORMAL:
+		glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+		break;
+	case S3DE_BLEND_ADDITIVE:
+		glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ZERO, GL_ONE);
+		break;
+	}
+	glActiveTexture(GL_TEXTURE0);
+	glUniform1i(r->texture, 0);
+	glBindVertexArray(r->billboard_vao);
+	glDisable(GL_CULL_FACE);
+	glBindTexture(GL_TEXTURE_2D, bt->texture);
+
+	for (int i = 0; i < obj->particle_count; i++) {
+		struct s3de_particle *p = &st->particles[i];
+		float alpha;
+		if (!s3de_particle_alpha(st, p, frame, &alpha))
+			continue;
+
+		mat4 world;
+		if (!s3de_billboard_world_transform(inst, obj, st, p, frame, camera_rot, world))
+			continue;
+
+		glUniform1f(r->alpha_mod, alpha);
+		glUniformMatrix4fv(r->local_transform, 1, GL_FALSE, world[0]);
+		glUniformMatrix3fv(r->normal_transform, 1, GL_FALSE, world[0]);
+
+		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	}
+
+	glEnable(GL_CULL_FACE);
+	glBindVertexArray(0);
+	glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+static void render_s3de_polygon_particles(struct RE_renderer *r, struct RE_instance *inst,
+					  struct s3de_object *obj, struct s3de_object_state *st,
+					  mat3 camera_rot, vec3 camera_pos, float frame,
+					  enum draw_phase phase)
+{
+	struct model *model = obj->model;
+	if (!model || obj->particle_count == 0)
+		return;
+
+	if (phase == DRAW_OPAQUE && st->emitter_alpha < 1.0f)
+		return;
+
+	glUniform1i(r->diffuse_type, DIFFUSE_NORMAL);
+	// The .3de blend_type is ignored for polygon objects. Per-mesh additive
+	// blend modes are not yet handled.
+	glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+
+	for (int i = 0; i < obj->particle_count; i++) {
+		struct s3de_particle *p = &st->particles[i];
+		float alpha;
+		if (!s3de_particle_alpha(st, p, frame, &alpha))
+			continue;
+		if (phase == DRAW_OPAQUE && alpha < 1.0f)
+			continue;
+
+		mat4 world;
+		if (!s3de_mesh_world_transform(inst, obj, st, p, frame, camera_rot, camera_pos, world))
+			continue;
+
+		glUniform1f(r->alpha_mod, alpha);
+		glUniformMatrix4fv(r->local_transform, 1, GL_FALSE, world[0]);
+		glUniformMatrix3fv(r->normal_transform, 1, GL_FALSE, world[0]);
+
+		for (int j = 0; j < model->nr_meshes; j++) {
+			struct mesh *mesh = &model->meshes[j];
+			bool is_transparent = mesh->is_transparent || alpha < 1.0f;
+			if (phase != (is_transparent ? DRAW_TRANSPARENT : DRAW_OPAQUE))
+				continue;
+			struct material *material = &model->materials[mesh->material];
+
+			glActiveTexture(GL_TEXTURE0);
+			glBindTexture(GL_TEXTURE_2D, material->color_maps[0]);
+			glUniform1i(r->texture, 0);
+			glBindVertexArray(mesh->vao);
+
+			if (mesh->flags & MESH_BOTH)
+				glDisable(GL_CULL_FACE);
+			glDrawArrays(GL_TRIANGLES, 0, mesh->nr_vertices);
+			if (mesh->flags & MESH_BOTH)
+				glEnable(GL_CULL_FACE);
+
+			glBindVertexArray(0);
+			glBindTexture(GL_TEXTURE_2D, 0);
+		}
+	}
+}
+
+// Sort entry for per-object ordering.
+struct s3de_obj_sort_key {
+	float key;
+	int idx;
+};
+
+static int cmp_s3de_obj(const void *lhs, const void *rhs)
+{
+	const struct s3de_obj_sort_key *l = lhs;
+	const struct s3de_obj_sort_key *r = rhs;
+	if (l->key != r->key)
+		return (l->key > r->key) - (l->key < r->key);
+	// Fall back to declaration order to keep the sort stable.
+	return (l->idx > r->idx) - (l->idx < r->idx);
+}
+
+static void render_s3de_effect(struct RE_instance *inst, struct RE_renderer *r, enum draw_phase phase)
+{
+	if (!inst->s3de_effect || !inst->draw)
+		return;
+
+	if (inst->local_transform_needs_update)
+		RE_instance_update_local_transform(inst);
+
+	glUniform3fv(r->instance_ambient, 1, inst->ambient);
+	glUniform3f(r->diffuse_mod, 1.f, 1.f, 1.f);
+
+	glUniform1i(r->has_bones, GL_FALSE);
+	glUniform1f(r->specular_strength, 0.0);
+	glUniform1f(r->specular_shininess, 0.0);
+	glUniform1i(r->use_specular_map, GL_FALSE);
+	glUniform1f(r->rim_exponent, 0.0);
+	glUniform1i(r->use_normal_map, GL_FALSE);
+	glUniform1f(r->shadow_darkness, 0.0f);
+	glUniform1i(r->alpha_mode, ALPHA_BLEND);
+	glUniform1i(r->fog_type, 0);
+
+	if (phase == DRAW_TRANSPARENT)
+		glDepthMask(GL_FALSE);
+
+	mat4 view_mat;
+	RE_calc_view_matrix(&inst->plugin->camera, NULL, view_mat);
+	mat3 camera_rot;
+	glm_mat4_pick3t(view_mat, camera_rot);
+
+	struct s3de *s = inst->s3de_effect->s3de;
+
+	// Sort objects by their emitter's world-space distance to the camera.
+	// The transparent phase draws back-to-front, the opaque phase draws
+	// front-to-back. Particles inside one object are not sorted; they stay
+	// in spawn order.
+	float *camera_pos = inst->plugin->camera.override_active
+		? inst->plugin->camera.override_pos : inst->plugin->camera.pos;
+	float key_sign = phase == DRAW_OPAQUE ? 1.0f : -1.0f;
+	struct s3de_obj_sort_key *keys = xmalloc(s->nr_objects * sizeof(*keys));
+	for (int i = 0; i < s->nr_objects; i++) {
+		keys[i].idx = i;
+		vec3 emitter_world;
+		glm_mat4_mulv3(inst->local_transform,
+			inst->s3de_effect->objects[i].emitter_pos, 1.0f,
+			emitter_world);
+		vec3 d;
+		glm_vec3_sub(emitter_world, camera_pos, d);
+		keys[i].key = key_sign * glm_vec3_norm2(d);
+	}
+	qsort(keys, s->nr_objects, sizeof(*keys), cmp_s3de_obj);
+
+	float frame = inst->motion->current_frame;
+
+	for (int k = 0; k < s->nr_objects; k++) {
+		int i = keys[k].idx;
+		struct s3de_object *obj = &s->objects[i];
+		struct s3de_object_state *st = &inst->s3de_effect->objects[i];
+
+		glUniform3fv(r->diffuse_mod, 1, st->multiply_color);
+		glUniform3fv(r->color_add, 1, st->additive_color);
+
+		switch (obj->type) {
+		case S3DE_OBJ_BILLBOARD:
+			// Billboards are transparent-phase only.
+			if (phase == DRAW_TRANSPARENT)
+				render_s3de_billboard_particles(r, inst, obj, st, camera_rot, frame);
+			break;
+		case S3DE_OBJ_POLYGON:
+			render_s3de_polygon_particles(r, inst, obj, st, camera_rot, camera_pos, frame, phase);
+			break;
+		case S3DE_OBJ_CAMERA:
+			break;
+		}
+	}
+	free(keys);
+
+	glUniform3f(r->diffuse_mod, 1.0f, 1.0f, 1.0f);
+	glUniform3f(r->color_add, 0.0f, 0.0f, 0.0f);
+	if (phase == DRAW_TRANSPARENT)
+		glDepthMask(GL_TRUE);
+}
+
 static void render_particle_effect(struct RE_instance *inst, struct RE_renderer *r, enum draw_phase phase)
 {
 	// NOTE: inst->draw flag has no effect for particle effects.
@@ -749,7 +954,10 @@ static void render_instance(struct RE_instance *inst, struct RE_renderer *r, mat
 		render_billboard(inst, r, view_mat, phase);
 		break;
 	case RE_ITYPE_PARTICLE_EFFECT:
-		render_particle_effect(inst, r, phase);
+		if (inst->s3de_effect)
+			render_s3de_effect(inst, r, phase);
+		else
+			render_particle_effect(inst, r, phase);
 		break;
 	default:
 		break;

--- a/src/3d/s3de.c
+++ b/src/3d/s3de.c
@@ -24,6 +24,8 @@
 
 #include "system4.h"
 #include "system4/aar.h"
+#include "system4/cg.h"
+#include "system4/hashtable.h"
 #include "system4/utfsjis.h"
 
 #include "3d_internal.h"
@@ -562,6 +564,60 @@ err:
 	return NULL;
 }
 
+static void load_textures(struct s3de *s, struct archive *aar)
+{
+	s->textures = ht_create(16);
+	for (int i = 0; i < s->nr_objects; i++) {
+		struct s3de_object *o = &s->objects[i];
+		const char *name = o->texture;
+		if (!name || ht_get(s->textures, name, NULL))
+			continue;
+
+		struct archive_data *dfile = RE_get_aar_entry(aar, s->path, name, ".png");
+		if (!dfile) {
+			WARNING("cannot load texture %s\\%s", s->path, name);
+			continue;
+		}
+		struct cg *cg = cg_load_data(dfile);
+		if (!cg) {
+			WARNING("cg_load_data failed: %s", dfile->name);
+			archive_free_data(dfile);
+			continue;
+		}
+		archive_free_data(dfile);
+
+		GLuint texture;
+		glGenTextures(1, &texture);
+		glBindTexture(GL_TEXTURE_2D, texture);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, cg->metrics.w, cg->metrics.h, 0, GL_RGBA, GL_UNSIGNED_BYTE, cg->pixels);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+		glGenerateMipmap(GL_TEXTURE_2D);
+		glBindTexture(GL_TEXTURE_2D, 0);
+
+		struct billboard_texture *bt = xcalloc(1, sizeof(struct billboard_texture));
+		bt->texture = texture;
+		bt->has_alpha = cg->metrics.has_alpha;
+		ht_put(s->textures, name, bt);
+		cg_free(cg);
+	}
+}
+
+static void load_polygons(struct s3de *s, struct archive *aar)
+{
+	for (int i = 0; i < s->nr_objects; i++) {
+		struct s3de_object *o = &s->objects[i];
+		if (o->polygon_name && *o->polygon_name) {
+			char *pol_path = xmalloc(strlen(s->path) + strlen(o->polygon_name) + 2);
+			sprintf(pol_path, "%s\\%s", s->path, o->polygon_name);
+			o->model = model_load(aar, pol_path);
+			free(pol_path);
+		}
+	}
+}
+
 struct s3de *s3de_load(struct archive *aar, const char *path)
 {
 	const char *basename = strrchr(path, '\\');
@@ -589,8 +645,17 @@ struct s3de *s3de_load(struct archive *aar, const char *path)
 	archive_free_data(dfile);
 
 	s->path = strdup(path);
+	load_textures(s, aar);
+	load_polygons(s, aar);
 
 	return s;
+}
+
+static void free_billboard_texture(void *value)
+{
+	struct billboard_texture *bt = value;
+	glDeleteTextures(1, &bt->texture);
+	free(bt);
 }
 
 void s3de_free(struct s3de *s)
@@ -610,10 +675,35 @@ void s3de_free(struct s3de *s)
 		free(o->rotation_list);
 		free(o->multiply_color_list);
 		free(o->additive_color_list);
+		if (o->model)
+			model_free(o->model);
+	}
+	if (s->textures) {
+		ht_foreach_value(s->textures, free_billboard_texture);
+		ht_free(s->textures);
 	}
 	free(s->objects);
 	free(s->path);
 	free(s);
+}
+
+static float interp_scalar(struct s3de_scalar_entry *list, int n, float frame, float def)
+{
+	if (n == 0)
+		return def;
+	if (frame <= list[0].frame)
+		return list[0].value;
+	if (frame >= list[n - 1].frame)
+		return list[n - 1].value;
+	int k = 0;
+	while (k + 1 < n && list[k + 1].frame <= frame)
+		k++;
+	struct s3de_scalar_entry *a = &list[k];
+	struct s3de_scalar_entry *b = &list[k + 1];
+	if (a->interp == S3DE_INTERP_NONE)
+		return a->value;
+	float t = (frame - a->frame) / (float)(b->frame - a->frame);
+	return glm_lerp(a->value, b->value, t);
 }
 
 static void interp_vec3(struct s3de_vec3_entry *list, int n, float frame, vec3 dest, vec3 def)
@@ -643,7 +733,70 @@ static void interp_vec3(struct s3de_vec3_entry *list, int n, float frame, vec3 d
 	glm_vec3_lerp(a->v, b->v, t, dest);
 }
 
-static void interp_pos(struct s3de_position_entry *list, int n, float frame, vec3 dest)
+// Evaluate position along the Bezier curve formed by consecutive cubic segments
+// (with possible quadratic/linear fallback for the final segment).
+static void interp_pos_bezier(struct s3de_position_entry *list, int n, float frame, vec3 dest)
+{
+	int k = 0;
+	while (k + 1 < n) {
+		// Hold: snap to this entry's position until the next entry.
+		if (list[k].interp == S3DE_INTERP_NONE) {
+			if (frame < list[k + 1].frame) {
+				glm_vec3_copy(list[k].pos, dest);
+				return;
+			}
+			k++;
+			continue;
+		}
+
+		// Determine segment degree from remaining entries.
+		// Prefer cubic (4 points), fall back to quadratic (3) or linear (2).
+		int degree = min(n - 1 - k, 3);
+		int seg_end = k + degree;
+		// If frame lies within this segment or this is the last segment,
+		// evaluate the Bezier curve.
+		if (frame < list[seg_end].frame || seg_end == n - 1) {
+			// For simplicity, t is mapped linearly within a segment.
+			float t = (frame - list[k].frame) /
+				  (float)(list[seg_end].frame - list[k].frame);
+			// De Casteljau's algorithm.
+			vec3 tmp[4];
+			for (int i = 0; i <= degree; i++)
+				glm_vec3_copy(list[k + i].pos, tmp[i]);
+			for (int d = degree; d > 0; d--)
+				for (int i = 0; i < d; i++)
+					glm_vec3_lerp(tmp[i], tmp[i + 1], t, tmp[i]);
+			glm_vec3_copy(tmp[0], dest);
+			return;
+		}
+		// Skip to the start of the next cubic segment.
+		k += 3;
+	}
+	glm_vec3_copy(list[n - 1].pos, dest);
+}
+
+// Linear-mode segment lookup.
+// Caller must ensure n >= 2 and list[0].frame < frame < list[n-1].frame.
+static void find_pos_segment(struct s3de_position_entry *list, int n, float frame,
+			     int *k_out, float *t_out)
+{
+	// The boundary guarantee above keeps k <= n-2, so list[k+1] is valid.
+	int k = 0;
+	while (k + 1 < n && list[k + 1].frame <= frame)
+		k++;
+	*k_out = k;
+	if (list[k].interp == S3DE_INTERP_NONE) {
+		// t <- 0, so the caller can lerp unconditionally and naturally hold
+		// list[k]'s value.
+		*t_out = 0.0f;
+	} else {
+		// Linear interpolation.
+		*t_out = (frame - list[k].frame) / (float)(list[k + 1].frame - list[k].frame);
+	}
+}
+
+static void interp_pos(struct s3de_position_entry *list, int n, float frame,
+		       enum s3de_move_type move_type, vec3 dest)
 {
 	if (n == 0) {
 		glm_vec3_zero(dest);
@@ -657,24 +810,654 @@ static void interp_pos(struct s3de_position_entry *list, int n, float frame, vec
 		glm_vec3_copy(list[n - 1].pos, dest);
 		return;
 	}
-	int k = 0;
-	while (k + 1 < n && list[k + 1].frame <= frame)
-		k++;
-	struct s3de_position_entry *a = &list[k];
-	struct s3de_position_entry *b = &list[k + 1];
-	if (a->interp == S3DE_INTERP_NONE) {
-		glm_vec3_copy(a->pos, dest);
+	switch (move_type) {
+	case S3DE_MOVE_LINEAR: {
+		int k;
+		float t;
+		find_pos_segment(list, n, frame, &k, &t);
+		glm_vec3_lerp(list[k].pos, list[k + 1].pos, t, dest);
+		break;
+	}
+	case S3DE_MOVE_BEZIER:
+		interp_pos_bezier(list, n, frame, dest);
+		break;
+	}
+}
+
+// Interpolate the per-entry (spawn_radius, spawn_angle_deg) pair at `frame`.
+static void interp_spawn_params(struct s3de_position_entry *list, int n, float frame,
+				float *radius_out, float *angle_deg_out)
+{
+	if (n == 0) {
+		*radius_out = 0.0f;
+		*angle_deg_out = 0.0f;
 		return;
 	}
-	float t = (frame - a->frame) / (float)(b->frame - a->frame);
-	glm_vec3_lerp(a->pos, b->pos, t, dest);
+	if (frame <= list[0].frame) {
+		*radius_out = list[0].spawn_radius;
+		*angle_deg_out = list[0].spawn_angle_deg;
+		return;
+	}
+	if (frame >= list[n - 1].frame) {
+		*radius_out = list[n - 1].spawn_radius;
+		*angle_deg_out = list[n - 1].spawn_angle_deg;
+		return;
+	}
+	int k;
+	float t;
+	find_pos_segment(list, n, frame, &k, &t);
+	*radius_out    = glm_lerp(list[k].spawn_radius,    list[k + 1].spawn_radius,    t);
+	*angle_deg_out = glm_lerp(list[k].spawn_angle_deg, list[k + 1].spawn_angle_deg, t);
+}
+
+// Deterministic per-emitter PRNG (splitmix32), so repeated playback produces
+// identical particle layouts.
+struct s3de_rng { uint32_t state; };
+
+static inline uint32_t rng_next_u32(struct s3de_rng *r)
+{
+	uint32_t z = (r->state += 0x9e3779b9u);
+	z = (z ^ (z >> 16)) * 0x85ebca6bu;
+	z = (z ^ (z >> 13)) * 0xc2b2ae35u;
+	return z ^ (z >> 16);
+}
+
+// Uniform float in [0, 1).
+static inline float randf(struct s3de_rng *r)
+{
+	return (float)(rng_next_u32(r) >> 8) * (1.0f / 16777216.0f);
+}
+
+static inline float eval_range(struct s3de_rng *rng, struct s3de_range r)
+{
+	// base + uniform([-random/2, +random/2]).
+	return r.base + (randf(rng) - 0.5f) * r.random;
+}
+
+// Uniform sampling on the unit sphere.
+static void random_unit_vec3(struct s3de_rng *rng, vec3 dest)
+{
+	float z = randf(rng) * 2.0f - 1.0f;
+	float phi = randf(rng) * 2.0f * GLM_PIf;
+	float r = sqrtf(fmaxf(0.0f, 1.0f - z * z));
+	dest[0] = r * cosf(phi);
+	dest[1] = r * sinf(phi);
+	dest[2] = z;
+}
+
+// Rejection sample inside the unit ball: pick three uniforms in [-1, 1] and
+// retry until inside.
+static void random_in_unit_ball(struct s3de_rng *rng, vec3 dest)
+{
+	for (int i = 0; i < 100; i++) {
+		float x = randf(rng) * 2.0f - 1.0f;
+		float y = randf(rng) * 2.0f - 1.0f;
+		float z = randf(rng) * 2.0f - 1.0f;
+		if (x * x + y * y + z * z <= 1.0f) {
+			dest[0] = x; dest[1] = y; dest[2] = z;
+			return;
+		}
+	}
+	dest[0] = 1.0f; dest[1] = 0.0f; dest[2] = 0.0f;
+}
+
+// Same idea but for an XZ-plane disk; y is fixed to 0.
+static void random_in_unit_disk_xz(struct s3de_rng *rng, vec3 dest)
+{
+	for (int i = 0; i < 100; i++) {
+		float x = randf(rng) * 2.0f - 1.0f;
+		float z = randf(rng) * 2.0f - 1.0f;
+		if (x * x + z * z <= 1.0f) {
+			dest[0] = x; dest[1] = 0.0f; dest[2] = z;
+			return;
+		}
+	}
+	dest[0] = 1.0f; dest[1] = 0.0f; dest[2] = 0.0f;
+}
+
+// Sample a unit vector lying in the plane whose normal is `normal`.
+static void random_in_plane(struct s3de_rng *rng, vec3 normal, vec3 dest)
+{
+	vec3 r;
+	random_unit_vec3(rng, r);
+	// NOTE: This yields a zero vector if the cross is degenerate.
+	glm_vec3_crossn(normal, r, dest);
+}
+
+// Rejection-sample a unit vector within a cone of half-angle `angle_deg` around `axis`.
+static void randomize_direction_within_cone(struct s3de_rng *rng, vec3 axis, float angle_deg)
+{
+	if (!(angle_deg > 0.0f))
+		return;
+	float cos_t = cosf(glm_rad(angle_deg));
+	for (int i = 0; i < 100; i++) {
+		vec3 c;
+		random_unit_vec3(rng, c);
+		if (glm_vec3_dot(axis, c) >= cos_t) {
+			glm_vec3_copy(c, axis);
+			return;
+		}
+	}
+}
+
+static void init_particle_direction(struct s3de_rng *rng, struct s3de_object *obj,
+				     struct s3de_particle *p, vec3 dest)
+{
+	switch (obj->direction_type) {
+	case S3DE_DIR_SPECIFIED: {
+		// normalize(obj->direction), scattered within the cone.
+		glm_vec3_copy(obj->direction, dest);
+		float n2 = glm_vec3_norm2(dest);
+		if (n2 > 0.0f)
+			glm_vec3_scale(dest, 1.0f / sqrtf(n2), dest);
+		else
+			glm_vec3_copy(GLM_YUP, dest);
+		randomize_direction_within_cone(rng, dest, obj->direction_angle);
+		break;
+	}
+	case S3DE_DIR_EMITTER:
+		// spawn_dir (the emitter's velocity tangent at the spawn frame),
+		// scattered within the cone.
+		glm_vec3_copy(p->spawn_dir, dest);
+		randomize_direction_within_cone(rng, dest, obj->direction_angle);
+		break;
+	case S3DE_DIR_EMITTER_REVERSE:
+		// -spawn_dir, scattered within the cone.
+		glm_vec3_negate_to(p->spawn_dir, dest);
+		randomize_direction_within_cone(rng, dest, obj->direction_angle);
+		break;
+	case S3DE_DIR_ARBITRARY_PLANE:
+		// A random unit vector in the plane whose normal is obj->direction.
+		// Falls back to a fully random direction if the normal is zero.
+		if (glm_vec3_norm2(obj->direction) > 0.0f)
+			random_in_plane(rng, obj->direction, dest);
+		else
+			random_unit_vec3(rng, dest);
+		break;
+	case S3DE_DIR_SPAWN:
+		// normalize(spawn_offset), i.e. radially outward from the emitter
+		// center.
+		glm_vec3_normalize_to(p->spawn_offset, dest);
+		break;
+	case S3DE_DIR_EMITTER_COORD: {
+		// normalize(obj->direction) rotated from emitter-local to world
+		// space by the emitter rotation at the spawn frame.
+		vec3 local;
+		glm_vec3_normalize_to(obj->direction, local);
+		vec3 deg;
+		interp_vec3(obj->rotation_list, obj->nr_rotation_entries, p->begin_frame,
+			    deg, GLM_VEC3_ZERO);
+		vec3 rad = {
+			glm_rad(-deg[0]),
+			glm_rad(-deg[1]),
+			glm_rad(deg[2]),
+		};
+		mat4 R;
+		glm_euler_zxy(rad, R);
+		glm_mat4_mulv3(R, local, 0.0f, dest);
+		break;
+	}
+	case S3DE_DIR_RANDOM:
+	default:
+		// A fully random unit vector (uniform over the sphere).
+		random_unit_vec3(rng, dest);
+		break;
+	}
+}
+
+static void init_particle(struct s3de_rng *rng, struct s3de_object *obj, int index,
+			  struct s3de_particle *p)
+{
+	// Distribute spawn frames evenly across the position list's frame range.
+	float first_frame = 0.0f, last_frame = 0.0f;
+	if (obj->nr_position_entries > 0) {
+		first_frame = obj->position_list[0].frame;
+		last_frame = obj->position_list[obj->nr_position_entries - 1].frame;
+	}
+	float t = obj->particle_count > 1
+		? index / (float)(obj->particle_count - 1)
+		: 0.0f;
+	p->begin_frame = first_frame + t * (last_frame - first_frame);
+	p->end_frame = p->begin_frame + obj->child_frame;
+
+	// Per-particle quad pivot offset.
+	p->offset_x = eval_range(rng, obj->offset_x);
+	p->offset_y = eval_range(rng, obj->offset_y);
+
+	// Spawn position offset from the emitter, built in two stages:
+	//   offset = R_y(spawn_angle) * (spawn_radius, 0, 0)
+	//   offset += spawn_distance * random_unit_(sphere|disk)
+	float spawn_radius = 0.0f, spawn_angle = 0.0f;
+	interp_spawn_params(obj->position_list, obj->nr_position_entries,
+			    p->begin_frame, &spawn_radius, &spawn_angle);
+	glm_make_rad(&spawn_angle);
+	vec3 offset = {
+		spawn_radius * cosf(spawn_angle),
+		0.0f,
+		spawn_radius * sinf(spawn_angle),
+	};
+	if (obj->spawn_distance != 0.0f) {
+		vec3 sp = GLM_VEC3_ZERO_INIT;
+		if (obj->spawn_position_type == S3DE_SPAWN_SPHERE)
+			random_in_unit_ball(rng, sp);
+		else if (obj->spawn_position_type == S3DE_SPAWN_HORIZONTAL)
+			random_in_unit_disk_xz(rng, sp);
+		glm_vec3_muladds(sp, obj->spawn_distance, offset);
+	}
+	glm_vec3_copy(offset, p->spawn_offset);
+
+	// world_pos = emitter_pos(begin_frame) + spawn_offset
+	vec3 emitter_pos;
+	interp_pos(obj->position_list, obj->nr_position_entries, p->begin_frame,
+		   obj->movement_type, emitter_pos);
+	glm_vec3_add(emitter_pos, offset, p->world_pos);
+
+	// spawn_dir = normalize(emitter_pos(begin+0.1) - emitter_pos(begin-0.1))
+	{
+		const float delta = 0.1f;
+		vec3 p0, p1;
+		interp_pos(obj->position_list, obj->nr_position_entries,
+			   p->begin_frame - delta, obj->movement_type, p0);
+		interp_pos(obj->position_list, obj->nr_position_entries,
+			   p->begin_frame + delta, obj->movement_type, p1);
+		glm_vec3_sub(p1, p0, p->spawn_dir);
+		glm_vec3_normalize(p->spawn_dir);
+	}
+
+	init_particle_direction(rng, obj, p, p->direction);
+
+	p->speed = eval_range(rng, obj->speed);
+	p->accel = eval_range(rng, obj->acceleration);
+	p->movement_distance = eval_range(rng, obj->movement_distance);
+	p->movement_curve = eval_range(rng, obj->movement_curve);
+
+	p->start_size_scale = eval_range(rng, obj->start_size);
+	p->end_size_scale   = eval_range(rng, obj->end_size);
+	p->start_x_scale    = eval_range(rng, obj->start_x_size);
+	p->end_x_scale      = eval_range(rng, obj->end_x_size);
+	p->start_y_scale    = eval_range(rng, obj->start_y_size);
+	p->end_y_scale      = eval_range(rng, obj->end_y_size);
+
+	p->start_rotation_deg[0] = eval_range(rng, obj->start_x_rotation);
+	p->start_rotation_deg[1] = eval_range(rng, obj->start_y_rotation);
+	p->start_rotation_deg[2] = eval_range(rng, obj->start_z_rotation);
+	p->end_rotation_deg[0]   = eval_range(rng, obj->end_x_rotation);
+	p->end_rotation_deg[1]   = eval_range(rng, obj->end_y_rotation);
+	p->end_rotation_deg[2]   = eval_range(rng, obj->end_z_rotation);
+
+	p->fade_in_frames  = eval_range(rng, obj->alpha_fade_in_frame);
+	p->fade_out_frames = eval_range(rng, obj->alpha_fade_out_frame);
+}
+
+// Compute particle position in instance-local space at the given frame. Sums a
+// motion vector (distance traveled along p->direction, plus optional gravity)
+// onto a base position chosen by emitter_link_type.
+static void particle_local_pos(const struct s3de_object *obj,
+			     struct s3de_object_state *st,
+			     struct s3de_particle *p, float frame, vec3 dest)
+{
+	// Physics distance along p->direction: speed*t + 0.5*accel*t^2,
+	// where t is the elapsed time (rel_frame * 0.03) capped at the
+	// velocity-zero peak for accel < 0, so the particle stops there instead of
+	// reversing.
+	float rel_frame = frame - p->begin_frame;
+	float lifetime = p->end_frame - p->begin_frame;
+	float elapsed = rel_frame * 0.03f;
+	float motion_t = elapsed;
+	if (p->accel < 0.0f)
+		motion_t = fminf(motion_t, -p->speed / p->accel);
+	float dist = p->speed * motion_t + 0.5f * p->accel * motion_t * motion_t;
+	// Curve distance: movement_distance eased over the normalized lifetime.
+	//   f = pow(t, c)        if c > 1
+	//   f = t                if -1 <= c <= 1
+	//   f = 1 - pow(1-t, -c) if c < -1
+	if (p->movement_distance != 0.0f) {
+		float t_norm = lifetime > 0.0f ? rel_frame / lifetime : 0.0f;
+		t_norm = fminf(t_norm, 1.0f);
+		float c = p->movement_curve;
+		float ease;
+		if (c > 1.0f)
+			ease = powf(t_norm, c);
+		else if (c < -1.0f)
+			ease = 1.0f - powf(1.0f - t_norm, -c);
+		else
+			ease = t_norm;
+		dist += p->movement_distance * ease;
+	}
+	vec3 motion;
+	glm_vec3_scale(p->direction, dist, motion);
+	// free_fall subtracts a gravity Y offset from the motion vector.
+	if (obj->free_fall) {
+		const float g = 9.80665f;
+		float dy;
+		if (obj->mass != 0.0f && obj->air_resistance != 0.0f) {
+			// Viscous drag: the particle approaches a terminal velocity of mass*g/air
+			float e = expf(-(obj->air_resistance / obj->mass) * elapsed);
+			dy = (elapsed - (1.0f - e) * (obj->mass / obj->air_resistance))
+				* obj->mass * g / obj->air_resistance;
+		} else {
+			dy = elapsed * elapsed * g * 0.5f;
+		}
+		motion[1] -= dy;
+	}
+	// Base position by emitter_link_type.
+	switch (obj->emitter_link_type) {
+	case S3DE_LINK_FOLLOW:
+		// dest = current emitter_pos + spawn_offset + motion
+		glm_vec3_add(st->emitter_pos, p->spawn_offset, dest);
+		glm_vec3_add(dest, motion, dest);
+		break;
+	case S3DE_LINK_ROTATE_AT_SPAWN:
+	case S3DE_LINK_ROTATE_AT_CURRENT: {
+		// Rotate (spawn_offset + motion) by the current emitter rotation.
+		vec3 v;
+		glm_vec3_add(p->spawn_offset, motion, v);
+		vec3 rad = {
+			glm_rad(-st->emitter_rotation_deg[0]),
+			glm_rad(-st->emitter_rotation_deg[1]),
+			glm_rad(st->emitter_rotation_deg[2]),
+		};
+		mat4 R;
+		glm_euler_zxy(rad, R);
+		glm_mat4_mulv3(R, v, 0.0f, dest);
+		if (obj->emitter_link_type == S3DE_LINK_ROTATE_AT_SPAWN) {
+			// Rotate around emitter_pos at spawn.
+			glm_vec3_add(dest, p->world_pos, dest);
+			glm_vec3_sub(dest, p->spawn_offset, dest);
+		} else {
+			// Rotate around current emitter_pos.
+			glm_vec3_add(dest, st->emitter_pos, dest);
+		}
+		break;
+	}
+	case S3DE_LINK_NONE:
+	default:
+		// Spawn-time world_pos.
+		glm_vec3_add(p->world_pos, motion, dest);
+		break;
+	}
+}
+
+static void particle_scale(const struct s3de_particle *p,
+			 const struct s3de_object_state *st,
+			 float inst_scale, float t, vec3 out)
+{
+	float size = glm_lerp(p->start_size_scale, p->end_size_scale, t);
+	float sx = glm_lerp(p->start_x_scale, p->end_x_scale, t);
+	float sy = glm_lerp(p->start_y_scale, p->end_y_scale, t);
+	size *= st->emitter_size * inst_scale;
+	out[0] = size * sx * st->emitter_x_size;
+	out[1] = size * sy * st->emitter_y_size;
+	out[2] = size;
+}
+
+static void particle_rotation_mat(struct s3de_particle *p, float t, mat4 out)
+{
+	vec3 angles;
+	glm_vec3_lerp(p->start_rotation_deg, p->end_rotation_deg, t, angles);
+	angles[0] = glm_rad(-angles[0]);
+	angles[1] = glm_rad(-angles[1]);
+	angles[2] = glm_rad(angles[2]);
+	glm_euler_yxz(angles, out);
+}
+
+// Normalize v in place. Returns false when v is the zero vector.
+static bool try_normalize(vec3 v)
+{
+	if (glm_vec3_norm2(v) <= 0.0f)
+		return false;
+	glm_vec3_normalize(v);
+	return true;
+}
+
+// World-space, unit-length particle flight direction:
+// normalize(inst_xform * normalize(p->direction)). Returns false if degenerate.
+static bool particle_world_dir(struct s3de_particle *p, mat4 inst_xform, vec3 out)
+{
+	vec3 pdir;
+	glm_vec3_copy(p->direction, pdir);
+	if (!try_normalize(pdir))
+		return false;
+	glm_mat4_mulv3(inst_xform, pdir, 0.0f, out);
+	return try_normalize(out);
+}
+
+// Build the world-space posture basis (right, up, normal) for the billboard
+// posture types that orient the quad from the particle's flight direction.
+// Returns false for posture types NONE / CAMERA, and also when any
+// intermediate vector degenerates.
+static bool billboard_posture_basis(struct s3de_object *obj,
+				 struct s3de_particle *p,
+				 mat4 inst_xform, vec3 camera_front, mat3 out_rot)
+{
+	vec3 dir_world;
+	if (!particle_world_dir(p, inst_xform, dir_world))
+		return false;
+
+	vec3 right, up;
+	switch (obj->posture_type) {
+	case S3DE_POSE_MOVE_DIR:
+		glm_vec3_cross(camera_front, dir_world, right);
+		if (!try_normalize(right))
+			return false;
+		glm_vec3_cross(right, camera_front, up);
+		if (!try_normalize(up))
+			return false;
+		break;
+	case S3DE_POSE_MOVE_AND_FLY:
+	case S3DE_POSE_FLY_AND_EMITTER_MOVE: {
+		vec3 axis;
+		if (obj->posture_type == S3DE_POSE_MOVE_AND_FLY)
+			glm_vec3_copy(obj->direction, axis);
+		else
+			glm_vec3_copy(p->spawn_dir, axis);
+		if (!try_normalize(axis))
+			return false;
+		glm_vec3_copy(dir_world, up);
+		glm_vec3_cross(axis, up, right);
+		if (!try_normalize(right))
+			return false;
+		break;
+	}
+	case S3DE_POSE_NONE:
+	case S3DE_POSE_CAMERA:
+		return false;
+	}
+
+	vec3 normal;
+	glm_vec3_cross(right, up, normal);
+	glm_vec3_copy(right,  out_rot[0]);
+	glm_vec3_copy(up,     out_rot[1]);
+	glm_vec3_copy(normal, out_rot[2]);
+	return true;
+}
+
+// Build the world-space posture basis for polygon particles.
+static bool mesh_posture_basis(struct s3de_object *obj,
+			     struct s3de_particle *p,
+			     vec3 world_pos, vec3 camera_pos, vec3 camera_up,
+			     mat4 inst_xform, mat3 out_rot)
+{
+	vec3 right, up, forward;
+
+	switch (obj->posture_type) {
+	case S3DE_POSE_CAMERA:
+	case S3DE_POSE_MOVE_DIR:
+	case S3DE_POSE_MOVE_AND_FLY:
+		// Unlike the billboard path, the mesh path collapses these three
+		// modes into a single "look at the camera position" basis that
+		// ignores the particle's flight direction.
+		glm_vec3_sub(world_pos, camera_pos, forward);
+		if (!try_normalize(forward))
+			return false;
+		glm_vec3_cross(camera_up, forward, right);
+		if (!try_normalize(right))
+			return false;
+		glm_vec3_cross(forward, right, up);
+		break;
+	case S3DE_POSE_FLY_AND_EMITTER_MOVE: {
+		if (!particle_world_dir(p, inst_xform, up))
+			return false;
+		vec3 spawn;
+		glm_vec3_copy(p->spawn_dir, spawn);
+		if (!try_normalize(spawn))
+			return false;
+		glm_vec3_cross(spawn, up, forward);
+		if (!try_normalize(forward))
+			return false;
+		glm_vec3_cross(up, forward, right);
+		if (!try_normalize(right))
+			return false;
+		break;
+	}
+	case S3DE_POSE_NONE:
+		return false;
+	}
+
+	glm_vec3_copy(right,   out_rot[0]);
+	glm_vec3_copy(up,      out_rot[1]);
+	glm_vec3_copy(forward, out_rot[2]);
+	return true;
+}
+
+// Lifetime-dependent per-particle state.
+struct s3de_particle_xform {
+	float t;        // normalized lifetime position, 0..1
+	vec3 pos_local; // instance-local position
+	vec3 scale;
+	mat4 rmat;      // start->end rotation matrix
+};
+
+static bool eval_particle(struct RE_instance *inst, struct s3de_object *obj,
+			struct s3de_object_state *st, struct s3de_particle *p,
+			float frame, struct s3de_particle_xform *out)
+{
+	if (frame < p->begin_frame || p->end_frame <= frame)
+		return false;
+	float rel = frame - p->begin_frame;
+	float lifetime = p->end_frame - p->begin_frame;
+	out->t = lifetime > 0.0f ? rel / lifetime : 0.0f;
+	particle_local_pos(obj, st, p, frame, out->pos_local);
+	// Only the instance's scale_x sizes the quad/mesh; scale_y/_z affect
+	// position via the world matrix but not the particle size.
+	particle_scale(p, st, inst->scale[0], out->t, out->scale);
+	particle_rotation_mat(p, out->t, out->rmat);
+	return true;
+}
+
+// Current alpha (emitter alpha * per-particle fade) for one particle. Returns
+// false when the particle is not alive at `frame`.
+bool s3de_particle_alpha(struct s3de_object_state *st, struct s3de_particle *p,
+		float frame, float *alpha_out)
+{
+	if (frame < p->begin_frame || p->end_frame <= frame)
+		return false;
+	float rel = frame - p->begin_frame;
+	float total = p->end_frame - p->begin_frame;
+	float fade = 1.0f;
+	if (p->fade_in_frames > 0.0f && rel < p->fade_in_frames)
+		fade = glm_clamp_zo(rel / p->fade_in_frames);
+	else if (p->fade_out_frames > 0.0f && total - rel < p->fade_out_frames)
+		fade = glm_clamp_zo((total - rel) / p->fade_out_frames);
+	*alpha_out = st->emitter_alpha * fade;
+	return true;
+}
+
+// Build the full quad world matrix for one billboard particle:
+//   out = T(world_pos) * R_posture * R_particle * S * pivot
+bool s3de_billboard_world_transform(struct RE_instance *inst,
+		struct s3de_object *obj, struct s3de_object_state *st,
+		struct s3de_particle *p, float frame, mat3 camera_rot,
+		mat4 out)
+{
+	struct s3de_particle_xform px;
+	if (!eval_particle(inst, obj, st, p, frame, &px))
+		return false;
+
+	// world_pos = inst_xform * px.pos_local.
+	vec3 pos;
+	glm_mat4_mulv3(inst->local_transform, px.pos_local, 1.0f, pos);
+	glm_translate_make(out, pos);
+
+	mat3 rot;
+	if (!billboard_posture_basis(obj, p, inst->local_transform, camera_rot[2], rot)) {
+		// Fall back to the instance rotation (NONE) or the camera basis.
+		if (obj->posture_type == S3DE_POSE_NONE) {
+			vec3 euler = { glm_rad(inst->pitch), glm_rad(inst->yaw), glm_rad(inst->roll) };
+			mat4 m;
+			glm_euler(euler, m);
+			glm_mat4_pick3(m, rot);
+		} else {
+			glm_mat3_copy(camera_rot, rot);
+		}
+	}
+	glm_mat4_ins3(rot, out);
+
+	glm_mat4_mul(out, px.rmat, out);
+	glm_scale(out, px.scale);
+
+	glm_translate_x(out, -p->offset_x);
+	glm_translate_y(out, -p->offset_y);
+	return true;
+}
+
+// Build the full mesh world matrix for one polygon particle.
+bool s3de_mesh_world_transform(struct RE_instance *inst,
+		struct s3de_object *obj, struct s3de_object_state *st,
+		struct s3de_particle *p, float frame, mat3 camera_rot, vec3 camera_pos,
+		mat4 out)
+{
+	struct s3de_particle_xform px;
+	if (!eval_particle(inst, obj, st, p, frame, &px))
+		return false;
+
+	// world_pos = inst_xform * pos_local.
+	vec3 pos;
+	glm_mat4_mulv3(inst->local_transform, px.pos_local, 1.0f, pos);
+
+	mat3 rot;
+	if (mesh_posture_basis(obj, p, pos, camera_pos, camera_rot[1],
+				    inst->local_transform, rot)) {
+		// A world-space basis replaces the instance transform's rotation/scale:
+		//   out = T(world_pos) * R_posture * R_particle * S
+		glm_translate_make(out, pos);
+		glm_mat4_ins3(rot, out);
+		glm_mat4_mul(out, px.rmat, out);
+		glm_scale(out, px.scale);
+	} else {
+		// Keep the instance-local orientation:
+		//   out = inst_xform * ( T(pos_local) * R_particle * S )
+		mat4 local;
+		glm_translate_make(local, px.pos_local);
+		glm_mat4_mul(local, px.rmat, local);
+		glm_scale(local, px.scale);
+		glm_mat4_mul(inst->local_transform, local, out);
+	}
+	return true;
 }
 
 struct s3de_effect *s3de_effect_create(struct s3de *s, struct archive *aar)
 {
 	struct s3de_effect *eff = xcalloc(1, sizeof(struct s3de_effect));
 	eff->s3de = s;
+	eff->objects = xcalloc(s->nr_objects, sizeof(struct s3de_object_state));
 	eff->wav_channel = -1;
+
+	for (int i = 0; i < s->nr_objects; i++) {
+		struct s3de_object *obj = &s->objects[i];
+		struct s3de_object_state *st = &eff->objects[i];
+		// Default per-emitter values used when a list is empty.
+		st->emitter_size = st->emitter_x_size = st->emitter_y_size = 1.0f;
+		st->emitter_alpha = 1.0f;
+		glm_vec3_one(st->multiply_color);
+
+		if (obj->particle_count <= 0 || obj->type == S3DE_OBJ_CAMERA)
+			continue;
+		struct s3de_rng rng = {};
+		st->particles = xcalloc(obj->particle_count, sizeof(struct s3de_particle));
+		for (int j = 0; j < obj->particle_count; j++)
+			init_particle(&rng, obj, j, &st->particles[j]);
+	}
 
 	const char *basename = strrchr(s->path, '\\');
 	basename = basename ? basename + 1 : s->path;
@@ -697,6 +1480,11 @@ void s3de_effect_free(struct s3de_effect *eff)
 	if (eff->wav_channel >= 0) {
 		wav_stop(eff->wav_channel);
 		wav_unprepare(eff->wav_channel);
+	}
+	if (eff->objects) {
+		for (int i = 0; i < eff->s3de->nr_objects; i++)
+			free(eff->objects[i].particles);
+		free(eff->objects);
 	}
 	free(eff);
 }
@@ -747,21 +1535,35 @@ static void update_sound(struct s3de_effect *eff, struct motion *m)
 	eff->last_frame = frame;
 }
 
+static void update_object_states(struct s3de_effect *eff, float frame)
+{
+	for (int i = 0; i < eff->s3de->nr_objects; i++) {
+		struct s3de_object *obj = &eff->s3de->objects[i];
+		struct s3de_object_state *st = &eff->objects[i];
+		interp_pos(obj->position_list, obj->nr_position_entries, frame,
+			   obj->movement_type, st->emitter_pos);
+		interp_vec3(obj->rotation_list, obj->nr_rotation_entries, frame, st->emitter_rotation_deg, GLM_VEC3_ZERO);
+		if (obj->type == S3DE_OBJ_CAMERA)
+			continue;
+		st->emitter_size   = interp_scalar(obj->size_list,   obj->nr_size_entries,   frame, 1.0f);
+		st->emitter_x_size = interp_scalar(obj->x_size_list, obj->nr_x_size_entries, frame, 1.0f);
+		st->emitter_y_size = interp_scalar(obj->y_size_list, obj->nr_y_size_entries, frame, 1.0f);
+		st->emitter_alpha  = interp_scalar(obj->alpha_list,  obj->nr_alpha_entries,  frame, 1.0f);
+		interp_vec3(obj->multiply_color_list, obj->nr_multiply_color_entries, frame, st->multiply_color, GLM_VEC3_ONE);
+		interp_vec3(obj->additive_color_list, obj->nr_additive_color_entries, frame, st->additive_color, GLM_VEC3_ZERO);
+	}
+}
+
 static void update_camera_override(struct RE_instance *inst, struct s3de_effect *eff, float frame)
 {
 	int cam_idx = select_active_camera_obj(eff, frame);
 	if (cam_idx < 0 || !inst->plugin)
 		return;
 
-	struct s3de_object *obj = &eff->s3de->objects[cam_idx];
-	vec3 emitter_pos, emitter_rotation_deg;
-	interp_pos(obj->position_list, obj->nr_position_entries, frame, emitter_pos);
-	interp_vec3(obj->rotation_list, obj->nr_rotation_entries, frame,
-		    emitter_rotation_deg, GLM_VEC3_ZERO);
-
+	struct s3de_object_state *st = &eff->objects[cam_idx];
 	if (inst->local_transform_needs_update)
 		RE_instance_update_local_transform(inst);
-	vec4 local_pos = { emitter_pos[0], emitter_pos[1], emitter_pos[2], 1.0f };
+	vec4 local_pos = { st->emitter_pos[0], st->emitter_pos[1], st->emitter_pos[2], 1.0f };
 	vec4 world_pos;
 	glm_mat4_mulv(inst->local_transform, local_pos, world_pos);
 	struct RE_camera *cam = &inst->plugin->camera;
@@ -771,9 +1573,9 @@ static void update_camera_override(struct RE_instance *inst, struct s3de_effect 
 	// general, but it is exact here: in Rance 9 non-camera instances are only
 	// ever rotated about yaw. Since yaw is the outermost axis in the renderer's
 	// YXZ convention, the two yaw rotations combine exactly by addition.
-	cam->override_pitch = inst->pitch + emitter_rotation_deg[0];
-	cam->override_yaw   = inst->yaw   + emitter_rotation_deg[1];
-	cam->override_roll  = -(inst->roll + emitter_rotation_deg[2]);
+	cam->override_pitch = inst->pitch + st->emitter_rotation_deg[0];
+	cam->override_yaw   = inst->yaw   + st->emitter_rotation_deg[1];
+	cam->override_roll  = -(inst->roll + st->emitter_rotation_deg[2]);
 	cam->override_active = true;
 }
 
@@ -784,7 +1586,8 @@ void s3de_effect_update(struct RE_instance *inst)
 		return;
 	update_sound(eff, inst->motion);
 	float frame = inst->motion->current_frame;
-	update_camera_override(inst, eff, frame);
+	update_object_states(eff, frame);
+	update_camera_override(inst, eff, frame);  // must come after update_object_states()
 }
 
 void s3de_calc_frame_range(struct s3de *s, struct motion *motion)


### PR DESCRIPTION
This is probably the largest pull request for Rance 9.

At spawn, `init_particle()` samples its fixed properties from a deterministic PRNG into `s3de_particle`, so playback is reproducible.

Each frame, `update_object_states()` interpolates the emitter's animated properties into s3de_object_state.

To draw, `render_s3de_effect()` combines the two: for each live particle `s3de_billboard_world_transform()` or `s3de_mesh_world_transform()` derives a world matrix from the lifetime state computed by `eval_particle()`, together with a posture basis that orients the quad or mesh. Objects are drawn sorted by distance from the camera.