### PR TITLE
Use libsys4 zlib wrappers

### DIFF
--- a/src/hll/ACXLoader.c
+++ b/src/hll/ACXLoader.c
@@ -17,8 +17,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-#include <zlib.h>
-
 #include "system4.h"
 #include "system4/string.h"
 #include "system4/acx.h"

--- a/src/hll/BanMisc.c
+++ b/src/hll/BanMisc.c
@@ -17,12 +17,11 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include <zlib.h>
-
 #include "system4/file.h"
 #include "system4/little_endian.h"
 #include "system4/string.h"
 #include "system4/mt19937int.h"
+#include "system4/zlib.h"
 
 #include "hll.h"
 #include "audio.h"
@@ -47,14 +46,15 @@ static int BanMisc_SaveStruct(struct page *page, struct string *file_name)
 	iarray_free_writer(&out);
 
 	// compress
-	unsigned long compressed_size = compressBound(raw_size);
+	size_t compressed_size = zlib_compress_bound(raw_size);
 	uint8_t *buf = xmalloc(MD11_HEADER_SIZE + compressed_size);
 	memcpy(buf, md11_signature, sizeof(md11_signature));
 	LittleEndian_putDW(buf, 4, raw_size);
 	uint8_t *compressed = buf + MD11_HEADER_SIZE;
-	int r = compress2(compressed, &compressed_size, raw_buf, raw_size, Z_DEFAULT_COMPRESSION);
+	compressed_size = zlib_compress(compressed, compressed_size, raw_buf,
+			raw_size, ZLIB_DEFAULT_COMPRESSION);
 	free(raw_buf);
-	if (r != Z_OK) {
+	if (!compressed_size) {
 		free(buf);
 		return 0;
 	}
@@ -79,7 +79,7 @@ static struct page *load_md11(int struct_type, uint8_t *buf, size_t len)
 		WARNING("BanMisc.LoadStruct file too short");
 		return NULL;
 	}
-	unsigned long raw_size = LittleEndian_getDW(buf, 4);
+	size_t raw_size = LittleEndian_getDW(buf, 4);
 	if (raw_size % 4 != 0) {
 		WARNING("BanMisc.LoadStruct invalid file format");
 		return NULL;
@@ -92,9 +92,8 @@ static struct page *load_md11(int struct_type, uint8_t *buf, size_t len)
 
 	// decompress
 	uint8_t *raw_buf = xmalloc(raw_size);
-	int r = uncompress(raw_buf, &raw_size, buf, len);
-	if (r != Z_OK) {
-		WARNING("BanMisc.LoadStruct uncompress failed: %d", r);
+	if (!zlib_decompress_exact(raw_buf, raw_size, buf, len)) {
+		WARNING("BanMisc.LoadStruct uncompress failed");
 		free(raw_buf);
 		return NULL;
 	}

--- a/src/hll/Data.c
+++ b/src/hll/Data.c
@@ -15,12 +15,11 @@
  */
 
 #include <stdlib.h>
-#include <zlib.h>
-
 #include "system4/archive.h"
 #include "system4/buffer.h"
 #include "system4/little_endian.h"
 #include "system4/string.h"
+#include "system4/zlib.h"
 
 #include "hll.h"
 #include "asset_manager.h"
@@ -40,11 +39,11 @@ static int Data_Open(int num)
 	struct archive_data *dfile = asset_get(ASSET_DATA, num);
 	if (!dfile)
 		return 0;
-	unsigned long uncompressed_size = LittleEndian_getDW(dfile->data, 0);
+	size_t uncompressed_size = LittleEndian_getDW(dfile->data, 0);
 	uint8_t *buf = xmalloc(uncompressed_size);
-	int rv = uncompress(buf, &uncompressed_size, (uint8_t *)dfile->data + 4, dfile->size - 4);
-	if (rv != Z_OK) {
-		WARNING("%s: uncompress failed (%d)", dfile->name, rv);
+	if (!zlib_decompress_exact(buf, uncompressed_size,
+			(uint8_t *)dfile->data + 4, dfile->size - 4)) {
+		WARNING("%s: uncompress failed", dfile->name);
 		archive_free_data(dfile);
 		free(buf);
 		return 0;

--- a/src/hll/DataFile.c
+++ b/src/hll/DataFile.c
@@ -16,12 +16,11 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <zlib.h>
-
 #include "system4/archive.h"
 #include "system4/buffer.h"
 #include "system4/mt19937int.h"
 #include "system4/string.h"
+#include "system4/zlib.h"
 
 #include "hll.h"
 #include "asset_manager.h"
@@ -267,7 +266,7 @@ static int DataFile_Open(int link)
 	}
 	buffer_skip(&r, 4);
 
-	unsigned long uncompressed_size = buffer_read_int32(&r);
+	size_t uncompressed_size = buffer_read_int32(&r);
 	uint32_t compressed_size = buffer_remaining(&r);
 
 	// decode compressed data
@@ -277,10 +276,10 @@ static int DataFile_Open(int link)
 	mt19937_xorcode(compressed_data, compressed_size, 4588163);
 
 	uint8_t *raw = xmalloc(uncompressed_size);
-	int rv = uncompress(raw, &uncompressed_size, compressed_data, compressed_size);
+	bool ok = zlib_decompress_exact(raw, uncompressed_size, compressed_data, compressed_size);
 	free(compressed_data);
-	if (rv != Z_OK) {
-		WARNING("Uncompress failed: %d", rv);
+	if (!ok) {
+		WARNING("Uncompress failed");
 		free(raw);
 		return 0;
 	}

--- a/src/hll/File.c
+++ b/src/hll/File.c
@@ -20,13 +20,12 @@
 #include <string.h>
 #include <time.h>
 #include <sys/stat.h>
-#include <zlib.h>
-
 #include "system4.h"
 #include "system4/buffer.h"
 #include "system4/file.h"
 #include "system4/little_endian.h"
 #include "system4/string.h"
+#include "system4/zlib.h"
 
 #include "hll.h"
 #include "savedata.h"
@@ -180,12 +179,13 @@ static int File_Close(void)
 	int r = 1;
 	if (current_mode == FILE_WRITE) {
 		size_t raw_size = contents.index;
-		unsigned long compressed_size = compressBound(raw_size);
+		size_t compressed_size = zlib_compress_bound(raw_size);
 		uint8_t *buf = xmalloc(4 + compressed_size);
 		LittleEndian_putDW(buf, 0, raw_size);
-		int r = compress2(buf + 4, &compressed_size, contents.buf, raw_size, Z_DEFAULT_COMPRESSION);
-		if (r != Z_OK) {
-			WARNING("File.Close: compress2 failed");
+		compressed_size = zlib_compress(buf + 4, compressed_size, contents.buf,
+				raw_size, ZLIB_DEFAULT_COMPRESSION);
+		if (!compressed_size) {
+			WARNING("File.Close: zlib_compress failed");
 			r = 0;
 		} else {
 			if (fwrite(buf, 4 + compressed_size, 1, current_file) != 1) {
@@ -238,11 +238,11 @@ static int File_Read(struct page **_page)
 
 		// Check if it's ZLIB compressed
 		if (file_size > 6 && buf[4] == 0x78 && buf[5] == 0x9c) {
-			unsigned long raw_size = LittleEndian_getDW(buf, 0);
+			size_t raw_size = LittleEndian_getDW(buf, 0);
 			uint8_t *raw_buf = xmalloc(raw_size);
-			int r = uncompress(raw_buf, &raw_size, buf + 4, file_size);
+			bool ok = zlib_decompress_exact(raw_buf, raw_size, buf + 4, file_size - 4);
 			free(buf);
-			if (r != Z_OK) {
+			if (!ok) {
 				WARNING("File.Read failed to uncompress");
 				free(raw_buf);
 				return 0;
@@ -368,4 +368,3 @@ HLL_LIBRARY(File,
 	    //HLL_EXPORT(SetFind, File_SetFind),
 	    //HLL_EXPORT(GetFind, File_GetFind),
 	    HLL_EXPORT(MakeDirectory, File_MakeDirectory));
-

--- a/src/hll/PassRegister.c
+++ b/src/hll/PassRegister.c
@@ -18,7 +18,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <zlib.h>
 #include "cJSON.h"
 
 #include "system4.h"
@@ -26,6 +25,7 @@
 #include "system4/little_endian.h"
 #include "system4/string.h"
 #include "system4/file.h"
+#include "system4/zlib.h"
 
 #include "hll.h"
 #include "xsystem4.h"
@@ -97,10 +97,11 @@ static void write_register(unsigned handle)
 	}
 
 	size_t raw_size = buf.index;
-	unsigned long compressed_size = compressBound(raw_size);
+	size_t compressed_size = zlib_compress_bound(raw_size);
 	uint8_t *compressed = xmalloc(compressed_size);
-	int r = compress2(compressed, &compressed_size, buf.buf, raw_size, Z_BEST_COMPRESSION);
-	if (r != Z_OK) {
+	compressed_size = zlib_compress(compressed, compressed_size, buf.buf,
+			raw_size, ZLIB_BEST_COMPRESSION);
+	if (!compressed_size) {
 		WARNING("Failed to compress PassRegister file: %s", display_utf0(reg->filename));
 		goto end;
 	}
@@ -136,15 +137,14 @@ static void read_register_psr(struct passregister *reg, uint8_t *data, size_t da
 		WARNING("Unexpected PassRegister version %d", version);
 		return;
 	}
-	unsigned long raw_size = LittleEndian_getDW(data, 8);
+	size_t raw_size = LittleEndian_getDW(data, 8);
 	size_t compressed_size = LittleEndian_getDW(data, 12);
 	if (PSR_HEADER_SIZE + compressed_size != data_len) {
 		WARNING("Broken PassRegister file");
 		return;
 	}
 	uint8_t *raw = xmalloc(raw_size);
-	int r = uncompress(raw, &raw_size, data + PSR_HEADER_SIZE, compressed_size);
-	if (r != Z_OK) {
+	if (!zlib_decompress_exact(raw, raw_size, data + PSR_HEADER_SIZE, compressed_size)) {
 		WARNING("PassRegister: failed to uncompress");
 		free(raw);
 		return;

--- a/src/hll/Toushin3Loader.c
+++ b/src/hll/Toushin3Loader.c
@@ -17,13 +17,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zlib.h>
-
 #include "system4/little_endian.h"
 #include "system4/buffer.h"
 #include "system4/file.h"
 #include "system4/string.h"
 #include "system4/utfsjis.h"
+#include "system4/zlib.h"
 
 #include "hll.h"
 #include "vm/heap.h"
@@ -83,9 +82,9 @@ static uint8_t *read_compressed_data(FILE *fp, uint32_t *size)
 		free(buf);
 		return NULL;
 	}
-	unsigned long raw_size = LittleEndian_getDW(buf, 0);
+	size_t raw_size = LittleEndian_getDW(buf, 0);
 	void *raw = malloc(raw_size);
-	if (uncompress(raw, &raw_size, buf + 4, *size - 4) != Z_OK) {
+	if (!zlib_decompress_exact(raw, raw_size, buf + 4, *size - 4)) {
 		WARNING("uncompress failed");
 		free(raw);
 		free(buf);

--- a/src/swf.c
+++ b/src/swf.c
@@ -19,10 +19,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zlib.h>
 #include "system4.h"
 #include "system4/buffer.h"
 #include "system4/little_endian.h"
+#include "system4/zlib.h"
 #include "swf.h"
 
 static void free_tag_list(struct swf_tag *tags);
@@ -277,10 +277,9 @@ static struct swf_tag_define_bits_lossless *parse_define_bits_lossless(struct bu
 	if (tag->format != 5)
 		ERROR("DefineBitsLossless: unsupported format %d", tag->format);
 
-	unsigned long len = 4 * tag->width * tag->height;
+	size_t len = 4 * tag->width * tag->height;
 	uint8_t *pixels = xmalloc(len);
-	int rv = uncompress(pixels, &len, r->buf + r->index, buffer_remaining(r));
-	if (rv != Z_OK || len != 4 * tag->width * tag->height)
+	if (!zlib_decompress_exact(pixels, len, r->buf + r->index, buffer_remaining(r)))
 		ERROR("DefineBitsLossless: broken bitmap data");
 
 	uint8_t alpha_const = type == TAG_DEFINE_BITS_LOSSLESS ? 0xff : 0;
@@ -666,10 +665,10 @@ struct swf *aff_load(uint8_t *data, size_t size)
 		uint8_t *raw = xmalloc(raw_size);
 		memcpy(raw, buf, 8);
 		raw[0] = 'F';
-		unsigned long dest_size = raw_size - 8;
-		int rv = uncompress(raw + 8, &dest_size, buf + 8, size - 8);
+		size_t dest_size = raw_size - 8;
+		bool ok = zlib_decompress_exact(raw + 8, dest_size, buf + 8, size - 8);
 		free(buf);
-		if (rv != Z_OK || dest_size != raw_size - 8) {
+		if (!ok) {
 			free(raw);
 			return NULL;
 		}


### PR DESCRIPTION
Replace direct one-shot zlib compression and decompression calls with the libsys4 wrappers. Use exact-size decompression where file formats provide the uncompressed size.

File2.c continues to depend directly on zlib because it uses streaming inflate.