### PR TITLE
movie_ffmpeg: Use nb_samples for audio frame length

### DIFF
--- a/src/movie_ffmpeg.c
+++ b/src/movie_ffmpeg.c
@@ -175,7 +175,7 @@ static int audio_callback(sts_mixer_sample_t *sample, void *data)
 		return STS_STREAM_COMPLETE;
 	}
 	const int nr_channels = 2;
-	unsigned samples = mc->audio.frame->linesize[0] / mc->bytes_per_sample;
+	unsigned samples = mc->audio.frame->nb_samples;
 	if (samples * nr_channels != sample->length) {
 		free(sample->data);
 		sample->length = samples * nr_channels;


### PR DESCRIPTION
Audio `linesize` may include unused buffer space. Using it as the sample count caused short Vorbis frames to replay stale samples and slowed down audio playback.

This fixes the audio issue in MangaGamer Beat Blades Haruka mentioned in https://github.com/nunuhara/xsystem4/issues/154#issuecomment-2268196675.