### PR TITLE
PartsEngine: Stabilize save format for Rance 9

### DIFF
--- a/src/parts/save.c
+++ b/src/parts/save.c
@@ -22,7 +22,7 @@
 #include "parts_internal.h"
 #include "../hll/iarray.h"
 
-#define CURRENT_SAVE_VERSION 3
+#define CURRENT_SAVE_VERSION 4
 
 static void save_parts_params(struct iarray_writer *w, struct parts_params *params)
 {
@@ -562,18 +562,14 @@ static void save_parts(struct iarray_writer *w, struct parts *parts)
 	iarray_write(w, parts->draw_filter);
 	iarray_write(w, parts->message_window);
 	iarray_write(w, parts->alpha_clipper_parts_no);
-	// TODO: once the Rance 9 save format stabilizes, bump save version
-	// and save unconditionally
-	if (parts_multi_controller) {
-		iarray_write(w, parts->controller_no);
-		iarray_write(w, parts->pass_cursor);
-		iarray_write(w, parts->lock_input_state);
-		iarray_write(w, parts->margin_top);
-		iarray_write(w, parts->margin_bottom);
-		iarray_write(w, parts->margin_left);
-		iarray_write(w, parts->margin_right);
-		iarray_write(w, parts->draggable);
-	}
+	iarray_write(w, parts->controller_no);
+	iarray_write(w, parts->pass_cursor);
+	iarray_write(w, parts->lock_input_state);
+	iarray_write(w, parts->margin_top);
+	iarray_write(w, parts->margin_bottom);
+	iarray_write(w, parts->margin_left);
+	iarray_write(w, parts->margin_right);
+	iarray_write(w, parts->draggable);
 
 	unsigned motion_count_pos = iarray_writer_pos(w);
 	iarray_write(w, 0); // size of motion list
@@ -613,9 +609,7 @@ static void load_parts(struct iarray_reader *r, int version)
 		parts->message_window = iarray_read(r);
 	if (version > 2)
 		parts->alpha_clipper_parts_no = iarray_read(r);
-	// TODO: once the Rance 9 save format stabilizes, bump save version
-	// and load based on version check
-	if (parts_multi_controller) {
+	if (version > 3 || (version == 3 && parts_multi_controller)) {
 		parts->controller_no = iarray_read(r);
 		parts->pass_cursor = iarray_read(r);
 		parts->lock_input_state = iarray_read(r);
@@ -676,12 +670,8 @@ static bool parts_engine_save(struct page **buffer, bool save_hidden)
 	if (CURRENT_SAVE_VERSION > 1)
 		save_numeral_fonts(&w);
 
-	// TODO: once the Rance 9 save format stabilizes, bump save version
-	// and save unconditionally
-	if (parts_multi_controller) {
-		iarray_write(&w, ctrl_stack.active);
-		iarray_write(&w, ctrl_stack.nr_controllers);
-	}
+	iarray_write(&w, ctrl_stack.active);
+	iarray_write(&w, ctrl_stack.nr_controllers);
 
 	unsigned count_pos = iarray_writer_pos(&w);
 	iarray_write(&w, 0); // size of parts list
@@ -742,9 +732,7 @@ bool PE_Load(struct page **buffer)
 	if (version > 1)
 		load_numeral_fonts(&r);
 
-	// TODO: once the Rance 9 save format stabilizes, bump save version
-	// and load based on version check
-	if (parts_multi_controller) {
+	if (version > 3 || (version == 3 && parts_multi_controller)) {
 		ctrl_stack.active = iarray_read(&r);
 		ctrl_stack.nr_controllers = iarray_read(&r);
 	}


### PR DESCRIPTION
Bump the save version and always serialize controller state and the Rance 9 parts fields. Load these fields based on the save version while retaining compatibility with existing multi-controller saves.