### PR TITLE
Resolve archive paths in asset_manager_load_archive

### DIFF
--- a/src/asset_manager.c
+++ b/src/asset_manager.c
@@ -85,7 +85,10 @@ bool asset_manager_load_archive(enum asset_type type, const char *archive_name)
 		return false;
 	if (!assets[type]->load_archive)
 		ERROR("load_archive not supported on this archive type");
-	return assets[type]->load_archive(assets[type], archive_name);
+	char *path = gamedir_path(archive_name);
+	bool r = assets[type]->load_archive(assets[type], path);
+	free(path);
+	return r;
 }
 
 bool asset_exists(enum asset_type type, int id)

--- a/src/hll/CGManager.c
+++ b/src/hll/CGManager.c
@@ -17,7 +17,6 @@
 #include "system4/cg.h"
 #include "system4/string.h"
 #include "asset_manager.h"
-#include "xsystem4.h"
 #include "hll.h"
 
 static bool CGManager_Init(void *imain_system, int cg_cache_size)
@@ -27,10 +26,7 @@ static bool CGManager_Init(void *imain_system, int cg_cache_size)
 
 static bool CGManager_LoadArchive(struct string *archive_name)
 {
-	char *name = gamedir_path(archive_name->text);
-	bool r = asset_manager_load_archive(ASSET_CG, name);
-	free(name);
-	return r;
+	return asset_manager_load_archive(ASSET_CG, archive_name->text);
 }
 
 static bool CGManager_IsExist(struct string *cg_name)


### PR DESCRIPTION
`AFAFactory.LoadArchive` passed the SJIS archive name straight through, so the extra assets loaded by the Rance 9 v2.00 patch were never found. Move the path resolution out of `CGManager.LoadArchive` so that both callers share it.