### PR TITLE
parts: Reference construction process CGs by name

### DIFF
--- a/src/parts/construction.c
+++ b/src/parts/construction.c
@@ -34,15 +34,19 @@ void parts_cp_op_free(struct parts_cp_op *op)
 	switch (op->type) {
 	case PARTS_CP_CREATE:
 	case PARTS_CP_CREATE_PIXEL_ONLY:
-	case PARTS_CP_CG:
 	case PARTS_CP_FILL:
 	case PARTS_CP_FILL_ALPHA_COLOR:
 	case PARTS_CP_FILL_AMAP:
 	case PARTS_CP_FILL_WITH_ALPHA:
 	case PARTS_CP_DRAW_RECT:
+	case PARTS_CP_GRAY_FILTER:
+		break;
+	case PARTS_CP_CG:
+		free_string(op->cg.name);
+		break;
 	case PARTS_CP_DRAW_CUT_CG:
 	case PARTS_CP_COPY_CUT_CG:
-	case PARTS_CP_GRAY_FILTER:
+		free_string(op->cut_cg.cg_name);
 		break;
 	case PARTS_CP_DRAW_TEXT:
 	case PARTS_CP_COPY_TEXT:
@@ -92,8 +96,7 @@ bool PE_AddCreateCGToProcess(int parts_no, struct string *cg_name, int state)
 	if (!parts_state_valid(--state))
 		return false;
 
-	int no;
-	if (!asset_exists_by_name(ASSET_CG, cg_name->text, &no)) {
+	if (!asset_exists_by_name(ASSET_CG, cg_name->text, NULL)) {
 		WARNING("Invalid CG name: %s", display_sjis0(cg_name->text));
 		return false;
 	}
@@ -101,7 +104,7 @@ bool PE_AddCreateCGToProcess(int parts_no, struct string *cg_name, int state)
 	struct parts_construction_process *cproc = get_cproc(parts_no, state);
 	struct parts_cp_op *op = xcalloc(1, sizeof(struct parts_cp_op));
 	op->type = PARTS_CP_CG;
-	op->cg.no = no;
+	op->cg.name = string_ref(cg_name);
 	parts_add_cp_op(cproc, op);
 	return true;
 }
@@ -202,8 +205,7 @@ bool PE_AddDrawCutCGToPartsConstructionProcess(int parts_no, struct string *cg_n
 	if (!parts_state_valid(--state))
 		return false;
 
-	int cg_no;
-	if (!asset_exists_by_name(ASSET_CG, cg_name->text, &cg_no)) {
+	if (!asset_exists_by_name(ASSET_CG, cg_name->text, NULL)) {
 		WARNING("Invalid CG name: %s", display_sjis0(cg_name->text));
 		return false;
 	}
@@ -212,7 +214,7 @@ bool PE_AddDrawCutCGToPartsConstructionProcess(int parts_no, struct string *cg_n
 	struct parts_cp_op *op = xcalloc(1, sizeof(struct parts_cp_op));
 	op->type = PARTS_CP_DRAW_CUT_CG;
 	op->cut_cg = (struct parts_cp_cut_cg) {
-		.cg_no = cg_no,
+		.cg_name = string_ref(cg_name),
 		.dx = dx, .dy = dy, .dw = dw, .dh = dh,
 		.sx = sx, .sy = sy, .sw = sw, .sh = sh,
 		.interp_type = interp_type
@@ -228,8 +230,7 @@ bool PE_AddCopyCutCGToPartsConstructionProcess(int parts_no, struct string *cg_n
 	if (!parts_state_valid(--state))
 		return false;
 
-	int cg_no;
-	if (!asset_exists_by_name(ASSET_CG, cg_name->text, &cg_no)) {
+	if (!asset_exists_by_name(ASSET_CG, cg_name->text, NULL)) {
 		WARNING("Invalid CG name: %s", display_sjis0(cg_name->text));
 		return false;
 	}
@@ -238,7 +239,7 @@ bool PE_AddCopyCutCGToPartsConstructionProcess(int parts_no, struct string *cg_n
 	struct parts_cp_op *op = xcalloc(1, sizeof(struct parts_cp_op));
 	op->type = PARTS_CP_COPY_CUT_CG;
 	op->cut_cg = (struct parts_cp_cut_cg) {
-		.cg_no = cg_no,
+		.cg_name = string_ref(cg_name),
 		.dx = dx, .dy = dy, .dw = dw, .dh = dh,
 		.sx = sx, .sy = sy, .sw = sw, .sh = sh,
 		.interp_type = interp_type
@@ -355,7 +356,7 @@ static bool build_create_pixel_only(struct parts *parts, struct parts_constructi
 
 static bool build_cg(struct parts *parts, struct parts_construction_process *cproc, struct parts_cp_cg *op)
 {
-	struct cg *cg = asset_cg_load(op->no);
+	struct cg *cg = asset_cg_load_by_name(op->name->text, NULL);
 	if (!cg)
 		return false;
 	gfx_delete_texture(&cproc->common.texture);
@@ -415,7 +416,7 @@ static bool build_draw_cut_cg(struct parts_construction_process *cproc, struct p
 	if (!cproc->common.texture.handle)
 		return false;
 
-	struct cg *cg = asset_cg_load(op->cg_no);
+	struct cg *cg = asset_cg_load_by_name(op->cg_name->text, NULL);
 	assert(cg);
 
 	Texture src;
@@ -433,7 +434,7 @@ static bool build_copy_cut_cg(struct parts_construction_process *cproc, struct p
 	if (!cproc->common.texture.handle)
 		return false;
 
-	struct cg *cg = asset_cg_load(op->cg_no);
+	struct cg *cg = asset_cg_load_by_name(op->cg_name->text, NULL);
 	assert(cg);
 
 	Texture src;

--- a/src/parts/debug.c
+++ b/src/parts/debug.c
@@ -140,7 +140,7 @@ static void parts_construction_process_to_json(struct parts_construction_process
 			cJSON_AddNumberToObject(tmp, "h", op->create.h);
 			break;
 		case PARTS_CP_CG:
-			cJSON_AddNumberToObject(obj, "no", op->cg.no);
+			cJSON_AddSjisToObject(obj, "name", op->cg.name->text);
 			break;
 		case PARTS_CP_FILL:
 		case PARTS_CP_FILL_ALPHA_COLOR:
@@ -160,7 +160,7 @@ static void parts_construction_process_to_json(struct parts_construction_process
 			break;
 		case PARTS_CP_DRAW_CUT_CG:
 		case PARTS_CP_COPY_CUT_CG:
-			cJSON_AddNumberToObject(obj, "no", op->cut_cg.cg_no);
+			cJSON_AddSjisToObject(obj, "name", op->cut_cg.cg_name->text);
 			cJSON_AddItemToObjectCS(obj, "dst", tmp = cJSON_CreateObject());
 			cJSON_AddNumberToObject(tmp, "x", op->cut_cg.dx);
 			cJSON_AddNumberToObject(tmp, "y", op->cut_cg.dy);

--- a/src/parts/parts_internal.h
+++ b/src/parts/parts_internal.h
@@ -202,7 +202,7 @@ struct parts_cp_create {
 };
 
 struct parts_cp_cg {
-	int no;
+	struct string *name;
 };
 
 struct parts_cp_fill {
@@ -211,7 +211,7 @@ struct parts_cp_fill {
 };
 
 struct parts_cp_cut_cg {
-	int cg_no;
+	struct string *cg_name;
 	int dx, dy, dw, dh;
 	int sx, sy, sw, sh;
 	int interp_type;

--- a/src/parts/save.c
+++ b/src/parts/save.c
@@ -16,13 +16,15 @@
 
 #include "system4.h"
 #include "system4/string.h"
+#include "system4/archive.h"
 
 #include "vm/page.h"
+#include "asset_manager.h"
 #include "parts.h"
 #include "parts_internal.h"
 #include "../hll/iarray.h"
 
-#define CURRENT_SAVE_VERSION 4
+#define CURRENT_SAVE_VERSION 5
 
 static void save_parts_params(struct iarray_writer *w, struct parts_params *params)
 {
@@ -186,7 +188,7 @@ static void save_parts_cp_op(struct iarray_writer *w, struct parts_cp_op *op)
 		iarray_write(w, op->create.h);
 		break;
 	case PARTS_CP_CG:
-		iarray_write(w, op->cg.no);
+		iarray_write_string(w, op->cg.name);
 		break;
 	case PARTS_CP_FILL:
 	case PARTS_CP_FILL_ALPHA_COLOR:
@@ -204,7 +206,7 @@ static void save_parts_cp_op(struct iarray_writer *w, struct parts_cp_op *op)
 		break;
 	case PARTS_CP_DRAW_CUT_CG:
 	case PARTS_CP_COPY_CUT_CG:
-		iarray_write(w, op->cut_cg.cg_no);
+		iarray_write_string(w, op->cut_cg.cg_name);
 		iarray_write(w, op->cut_cg.dx);
 		iarray_write(w, op->cut_cg.dy);
 		iarray_write(w, op->cut_cg.dw);
@@ -233,7 +235,24 @@ static void save_parts_cp_op(struct iarray_writer *w, struct parts_cp_op *op)
 	}
 }
 
-static struct parts_cp_op *load_parts_cp_op(struct iarray_reader *r)
+static struct string *load_cp_cg_name(struct iarray_reader *r, int version)
+{
+	if (version >= 5)
+		return iarray_read_string(r);
+	// In version 4 and earlier, the CG name was stored as an integer ID.
+	// Convert it to a string name by looking up the asset.
+	int cg_no = iarray_read(r);
+	if (cg_no <= 0)
+		return string_ref(&EMPTY_STRING);
+	struct archive_data *data = asset_get(ASSET_CG, cg_no);
+	if (!data)
+		return string_ref(&EMPTY_STRING);
+	struct string *name = cstr_to_string(data->name);
+	archive_free_data(data);
+	return name;
+}
+
+static struct parts_cp_op *load_parts_cp_op(struct iarray_reader *r, int version)
 {
 	struct parts_cp_op *op = xcalloc(1, sizeof(struct parts_cp_op));
 	op->type = iarray_read(r);
@@ -244,7 +263,7 @@ static struct parts_cp_op *load_parts_cp_op(struct iarray_reader *r)
 		op->create.h = iarray_read(r);
 		break;
 	case PARTS_CP_CG:
-		op->cg.no = iarray_read(r);
+		op->cg.name = load_cp_cg_name(r, version);
 		break;
 	case PARTS_CP_FILL:
 	case PARTS_CP_FILL_ALPHA_COLOR:
@@ -262,7 +281,7 @@ static struct parts_cp_op *load_parts_cp_op(struct iarray_reader *r)
 		break;
 	case PARTS_CP_DRAW_CUT_CG:
 	case PARTS_CP_COPY_CUT_CG:
-		op->cut_cg.cg_no = iarray_read(r);
+		op->cut_cg.cg_name = load_cp_cg_name(r, version);
 		op->cut_cg.dx = iarray_read(r);
 		op->cut_cg.dy = iarray_read(r);
 		op->cut_cg.dw = iarray_read(r);
@@ -309,11 +328,11 @@ static void save_parts_construction_process(struct iarray_writer *w,
 }
 
 static void load_parts_construction_process(struct iarray_reader *r, struct parts *parts,
-		struct parts_construction_process *cproc)
+		struct parts_construction_process *cproc, int version)
 {
 	int ops_count = iarray_read(r);
 	for (int i = 0; i < ops_count; i++) {
-		struct parts_cp_op *op = load_parts_cp_op(r);
+		struct parts_cp_op *op = load_parts_cp_op(r, version);
 		parts_add_cp_op(cproc, op);
 	}
 	parts_build_construction_process(parts, cproc);
@@ -420,7 +439,7 @@ static void save_parts_state(struct iarray_writer *w, struct parts_state *state)
 }
 
 static void load_parts_state(struct iarray_reader *r, struct parts *parts,
-		struct parts_state *state)
+		struct parts_state *state, int version)
 {
 	parts_state_reset(state, iarray_read(r));
 	state->common.w = iarray_read(r);
@@ -453,7 +472,7 @@ static void load_parts_state(struct iarray_reader *r, struct parts *parts,
 		load_parts_gauge(r, parts, &state->gauge, true);
 		break;
 	case PARTS_CONSTRUCTION_PROCESS:
-		load_parts_construction_process(r, parts, &state->cproc);
+		load_parts_construction_process(r, parts, &state->cproc, version);
 		break;
 	case PARTS_FLASH:
 		load_parts_flash(r, parts, &state->flash);
@@ -590,7 +609,7 @@ static void load_parts(struct iarray_reader *r, int version)
 	struct parts *parts = parts_get(no);
 	parts->state = iarray_read(r);
 	for (int i = 0; i < PARTS_NR_STATES; i++) {
-		load_parts_state(r, parts, &parts->states[i]);
+		load_parts_state(r, parts, &parts->states[i], version);
 	}
 
 	load_parts_params(r, &parts->local);


### PR DESCRIPTION
Rance 9's AFA archives have no ID field, so asset IDs are sequential indices local to each archive. When the game loads an additional CG archive, the ID spaces overlap: a name resolved to an ID against the base archive later fetches a different CG from the additional archive. Keep the CG name instead.

Bumps the save version to 5; version 4 and earlier saves still store IDs and are converted on load.